### PR TITLE
Fix timeouts (SOFTWARE-2258), bugfixes, pylint, and UI changes

### DIFF
--- a/osgpkitools/ExceptionDefinitions.py
+++ b/osgpkitools/ExceptionDefinitions.py
@@ -15,18 +15,6 @@ class Exception_500response(Exception):
     def __str__(self):
         return str(self.message)
 
-class TimeoutException(Exception):
-    """ Exception raised for all timeouts
-
-    Attributes:
-        timeout -- timeout limit set after which the exception took place
-        """
-    def __init__(self,timeout):
-        self.timeout = timeout
-    
-    def __str__(self):
-        return "timeout: " + str(self.timeout)
-
 class FileNotFoundException(Exception):
     """ Exception raised when a file is not found
 

--- a/osgpkitools/ExceptionDefinitions.py
+++ b/osgpkitools/ExceptionDefinitions.py
@@ -11,7 +11,7 @@ class Exception_500response(Exception):
     def __init__(self, status, message):
         self.status = status
         self.message = message
-        
+
     def __str__(self):
         return str(self.message)
 
@@ -22,10 +22,10 @@ class FileNotFoundException(Exception):
         filename -- Name of the file that is not found
         message -- message to be printed for this exception
         """
-    def __init__(self,filename, message):
+    def __init__(self, filename, message):
         self.filename = filename
         self.message = message
-    
+
     def __str__(self):
         return str(self.message)
 
@@ -36,10 +36,10 @@ class NotOKException(Exception):
         status -- Status of the response
         message -- message of the failure reponse
         """
-    def __init__ (self,status,message):
+    def __init__(self, status, message):
         self.status = status
         self.message = message
-        
+
     def __str__(self):
         return "OK not found; status: %d; reason: %s" % (self.status, self.reason)
 
@@ -51,9 +51,9 @@ class UnexpectedBehaviourException(Exception):
     Attributes:
         message -- Message to be displayed
         """
-    def __init__(self,message):
+    def __init__(self, message):
         self.message = message
-        
+
     def __str__(self):
         return str(self.message)
 
@@ -71,7 +71,7 @@ class CertificateMismatchException(Exception):
         self.request_num = request_num
         self.retrieve_num = retrieve_num
         self.message = message
-    
+
     def __str__(self):
         return str(self.message)
 
@@ -81,9 +81,9 @@ class BadCertificateException(Exception):
     Attributes:
         message -- message to be displayed
         """
-    def __init__(self,message):
+    def __init__(self, message):
         self.message = message
-        
+
     def __str__(self):
         return str(self.message)
 
@@ -96,7 +96,7 @@ class BadPassphraseException(Exception):
         """
     def __init__(self, message):
         self.message = message
-    
+
     def __str__(self):
         return str(self.message)
 
@@ -106,9 +106,9 @@ class HandshakeFailureException(Exception):
     Attributes:
         message -- message to be displayed
         """
-    def __init__(self,message):
+    def __init__(self, message):
         self.message = message
-    
+
     def __str__(self):
         return str(self.message)
 
@@ -119,9 +119,9 @@ class QuotaException(Exception):
     Attributes:
         message = message to be displayed"""
 
-    def __init__(self,message):
+    def __init__(self, message):
         self.message = message
-    
+
     def __str__(self):
         return str(self.message)
 
@@ -130,9 +130,9 @@ class ValidationException(Exception):
     Attributes:
         message = message to be displayed"""
 
-    def __init__(self,message):
+    def __init__(self, message):
         self.message = message
-        
+
     def __str__(self):
         return str(self.message)
 
@@ -142,9 +142,9 @@ class InvalidOptionException(Exception):
     Attributes:
         message = message to be displayed"""
 
-    def __init__(self,message):
+    def __init__(self, message):
         self.message = message
-        
+
     def __str__(self):
         return str(self.message)
 
@@ -155,18 +155,18 @@ class NotApprovedException(Exception):
     Attributes:
         message = message to be displayed"""
 
-    def __init__(self,message):
+    def __init__(self, message):
         self.message = message
-        
+
     def __str__(self):
         return str(self.message)
 
 class InsufficientArgumentException(Exception):
     """This exception is raised when insufficient number of arguments are passed to a script."""
 
-    def __init__(self,message):
+    def __init__(self, message):
         self.message = message
-        
+
     def __str__(self):
         return str(self.message)
 
@@ -175,7 +175,7 @@ class FileWriteException(Exception):
 
     def __init__(self, message):
         self.message = message
-        
+
     def __str__(self):
         return str(self.message)
 

--- a/osgpkitools/OSGPKIUtils.py
+++ b/osgpkitools/OSGPKIUtils.py
@@ -182,7 +182,7 @@ def start_timeout_clock(minutes):
 def charlimit_textwrap(string):
     """This function wraps up the output to 80 characters. Accepts string and print the wrapped output"""
 
-    list_string = textwrap.wrap(str(string))
+    list_string = textwrap.wrap(str(string), width=80)
     for line in list_string:
         print line
     return

--- a/osgpkitools/OSGPKIUtils.py
+++ b/osgpkitools/OSGPKIUtils.py
@@ -1,8 +1,7 @@
 #!/usr/bin/python
 
-from M2Crypto import SSL, m2, RSA, EVP, X509
-import base64
 import ConfigParser
+from osgpkitools import ExceptionDefinitions
 import os
 import time
 import sys
@@ -12,7 +11,8 @@ import signal
 import traceback
 import getpass
 
-from ExceptionDefinitions import *
+from M2Crypto import SSL, m2, RSA, EVP, X509
+from optparse import OptionParser
 
 # These flags are for the purpose of passing to the M2Crypto calls and are used later in the script
 
@@ -21,7 +21,7 @@ MBSTRING_ASC = MBSTRING_FLAG | 1
 MBSTRING_BMP = MBSTRING_FLAG | 2
 
 # The variable for storing version number for the scripts
-Version_Number = "1.2.15"
+VERSION_NUMBER = "1.2.15"
 
 
 def get_ssl_context(**arguments):
@@ -36,10 +36,9 @@ def get_ssl_context(**arguments):
     ssl_context - ssl context for the HTTPS connection.
 
     """
-    first = True
     count = 0
     pass_str = 'Please enter the pass phrase for'
-    while(True):
+    while True:
         try:
             def prompt_for_password(verify):
                 return getpass.getpass(pass_str+" '%s':"
@@ -53,19 +52,18 @@ def get_ssl_context(**arguments):
             break
         except Exception, e:
             if 'sslv3 alert bad certificate' in e:
-                raise BadCertificateException('Error connecting to server: %s.\n\
-                                          Your certificate is not trusted by the server'
-                 % e)
+                raise ExceptionDefinitions.BadCertificateException('Error connecting to server: %s.\n' +
+                                                                   'Your certificate is not trusted by the server'
+                                                                   % e)
             elif 'handshake failure' in e:
-                raise HandshakeFailureException('Failure: %s.\nPlease check for valid certificate/key pairs.'
-                 % e)
-            first = False
+                raise ExceptionDefinitions.HandshakeFailureException('Failure: %s.\n' +
+                                                                     'Please check for valid certificate/key pairs.'
+                                                                     % e)
             count = count + 1
             pass_str = 'Incorrect password. Please enter the password again for'
             if count > 1:
-                raise BadPassphraseException('Incorrect passphrase. Attempt failed twice. Exiting script'
-                        )
-                break
+                err_msg = 'Incorrect passphrase. Attempt failed twice. Exiting script'
+                raise ExceptionDefinitions.BadPassphraseException(err_msg)
     return ssl_context
 
 
@@ -75,7 +73,7 @@ def print_exception_message(e):
     and traceback.
     """
 
-    if(str(e) != ""):
+    if str(e) != "":
         charlimit_textwrap("Got an exception %s" % e.__class__.__name__)
         charlimit_textwrap(e)
         charlimit_textwrap('Please report the bug to goc@opensciencegrid.org.')
@@ -91,22 +89,23 @@ def print_uncaught_exception():
 def handle_empty_exceptions(e):
     """The method handles all empty exceptions and displays a meaningful message and
     traceback for such exceptions."""
-    
+
     print traceback.format_exc()
     charlimit_textwrap('Encountered exception of type %s' % e.__class__.__name__)
     charlimit_textwrap('Please report the bug to goc@opensciencegrid.org.')
 
 def version_info():
     """ Print the version number and exit"""
-    print "OSG CLI Scripts Version :", Version_Number
+    print "OSG CLI Scripts Version :", VERSION_NUMBER
 
 def check_permissions(path):
     """The function checks for write permissions for the given path to verify if the user has write permissions
     """
-    if(os.access(path, os.W_OK)):
+    if os.access(path, os.W_OK):
         return
     else:
-        raise FileWriteException("User does not have appropriate permissions for writing to current directory.")
+        err_msg = "User does not have appropriate permissions for writing to current directory."
+        raise ExceptionDefinitions.FileWriteException(err_msg)
 
 def find_existing_file_count(filename):
     '''Check if filename and revisions of the filename exists. If so, increment the revision number and return
@@ -114,16 +113,16 @@ def find_existing_file_count(filename):
     temp_name = filename.split(".")[-2]
     trimmed_name = temp_name
     version_count = 0
-    if(os.path.exists(filename)):
-        while(os.path.exists(temp_name + '.pem')):
-            if (version_count == 0):
+    if os.path.exists(filename):
+        while os.path.exists(temp_name + '.pem'):
+            if version_count == 0:
                 temp_name = temp_name +'-'+str(version_count)
             else:
                 temp_name = trimmed_name
                 temp_name = temp_name + '-' + str(version_count)
             version_count = version_count + 1
 
-    if (version_count > 0):
+    if version_count > 0:
         version_count -= 1
         new_file = trimmed_name + '-' +str(version_count) + '.pem'
         return new_file
@@ -134,7 +133,7 @@ def check_response_500(response):
     """ This functions handles the 500 error response from the server"""
 
     if response.status == 500:
-        raise Exception_500response(response.status, response.reason)
+        raise ExceptionDefinitions.Exception_500response(response.status, response.reason)
 
 
 def check_failed_response(data):
@@ -149,11 +148,10 @@ def print_failure_reason_exit(data):
 
     try:
         charlimit_textwrap('The request has failed for the following reason:\n%s'
-                            % simplejson.loads(data)['detail'
-                           ].split('--')[1].lstrip())
-    except IndexError, e:
+                           % simplejson.loads(data)['detail'].split('--')[1].lstrip())
+    except IndexError:
         charlimit_textwrap('The request has failed for the following reason:\n%s'
-                            % simplejson.loads(data)['detail'].lstrip())
+                           % simplejson.loads(data)['detail'].lstrip())
         charlimit_textwrap('Status : %s '
                            % simplejson.loads(data)['status'])
     sys.exit(1)
@@ -222,8 +220,8 @@ def extractHostname(certString):
             if not 'DigiCert' in subStr.split('/CN=')[1].split('\n')[0]:
                 hostname = subStr.split('/CN=')[1].split('\n')[0]
     if hostname == '':
-        raise UnexpectedBehaviourException('Unexpected behaviour by OIM retrive API. EEC certificate not found'
-                )
+        err_msg = 'Unexpected behaviour by OIM retrive API. EEC certificate not found'
+        raise ExceptionDefinitions.UnexpectedBehaviourException(err_msg)
     return hostname
 
 
@@ -258,10 +256,10 @@ def CreateOIMConfig(isITB, **OIMConfig):
     ### Fix for pki-clients.ini not found in /etc/osg/
     elif os.path.exists('/etc/osg/pki-clients.ini'):
         Config.read('/etc/osg/pki-clients.ini')
-        
+
     else:
-        raise FileNotFoundException('pki-clients.ini',
-                                    'Could not locate the file')
+        raise ExceptionDefinitions.FileNotFoundException('pki-clients.ini',
+                                                         'Could not locate the file')
     if isITB:
         print 'Running in test mode'
         OIM = 'OIMData_ITB'
@@ -305,9 +303,9 @@ class Cert:
 ........It write the private key to the specified file name without ciphering it."""
 
         self.KeyPair = RSA.gen_key(self.RsaKey['KeyLength'],
-                self.RsaKey['PubExponent'],
-                self.RsaKey['keygen_callback'])
-        PubKey = RSA.new_pub_key(self.KeyPair.pub())
+                                   self.RsaKey['PubExponent'],
+                                   self.RsaKey['keygen_callback'])
+        RSA.new_pub_key(self.KeyPair.pub())
         self.KeyPair.save_key(filename, cipher=None)
         self.PKey = EVP.PKey(md='sha1')
         self.PKey.assign_rsa(self.KeyPair)

--- a/osgpkitools/osg-cert-request
+++ b/osgpkitools/osg-cert-request
@@ -8,30 +8,21 @@ user.
 import urllib
 import httplib
 import sys
-import ConfigParser
 import simplejson
-import base64
 import os
 from optparse import OptionParser
-import M2Crypto
-import textwrap
-import traceback
 import subprocess
 from ssl import SSLError
-from pprint import pprint
 
 from osgpkitools import OSGPKIUtils
 from osgpkitools import ConnectAPI
+from osgpkitools import ExceptionDefinitions
 from osgpkitools.OSGPKIUtils import version_info
 from osgpkitools.OSGPKIUtils import CreateOIMConfig
 from osgpkitools.OSGPKIUtils import check_response_500
 from osgpkitools.OSGPKIUtils import charlimit_textwrap
 from osgpkitools.OSGPKIUtils import check_failed_response
-from osgpkitools.OSGPKIUtils import version_info
-from osgpkitools.OSGPKIUtils import handle_empty_exceptions
 from osgpkitools.OSGPKIUtils import print_exception_message
-from osgpkitools.OSGPKIUtils import print_uncaught_exception
-from osgpkitools.ExceptionDefinitions import *
 
 
 # Set up Option Parser
@@ -57,8 +48,7 @@ def parse_args():
         action='store',
         dest='keyfile',
         help='Specify the output filename for the retrieved user certificate.\
-             \nDefault is ./hostkey.pem'
-            ,
+             \nDefault is ./hostkey.pem',
         metavar='OUTPUT KEYFILE',
         default='hostkey.pem',
         )
@@ -67,8 +57,7 @@ def parse_args():
         '--vo',
         action='store',
         dest='vo',
-        help='Specify the VO for the host request'
-            ,
+        help='Specify the VO for the host request',
         metavar='VO name',
         default=None,
         )
@@ -78,8 +67,7 @@ def parse_args():
         action='store',
         dest='cc_list',
         help='Specify the CC list(the email id\'s to be CCed). \
-             Separate values by \',\''
-            ,
+             Separate values by \',\'',
         metavar='CC LIST',
         default='',
         )
@@ -196,9 +184,9 @@ def parse_args():
             pem_filename = args.keyfile
             key_name = pem_filename.split("/")[-1].split(".")[-2]
             pem_filename_old = key_name + "-old.pem"
-            subprocess.call(['mv',  pem_filename , pem_filename_old])
+            subprocess.call(['mv', pem_filename, pem_filename_old])
             charlimit_textwrap("Moving existing file %s to %s "
-                               %(pem_filename ,pem_filename_old))
+                               % (pem_filename, pem_filename_old))
         else:
             pem_filename = args.keyfile
     else:
@@ -217,15 +205,13 @@ def parse_args():
 
     phone_num = phone.replace('-', '')
     if not phone_num.isdigit():
-        raise ValidationException("Phone number should contain \
-                                  only numbers and/or '-'\n"
-                                  )
+        raise ExceptionDefinitions.ValidationException("Phone number should contain only numbers and/or '-'\n")
     if args.csr is None:
         pass
     elif not os.path.exists(args.csr):
-        raise FileNotFoundException(args.csr,
-                                    'The file %s does not exist'
-                                    % args.csr)
+        raise ExceptionDefinitions.FileNotFoundException(args.csr,
+                                                         'The file %s does not exist'
+                                                         % args.csr)
 
     try:
         timeout = int(args.timeout)
@@ -285,12 +271,11 @@ def connect(arguments):
 
     print '\nConnecting to server...'
     params_list = {'name': arguments['name'],
-        'email': arguments['email'],
-        'phone': arguments['phone'],
-        'csrs': arguments['csr'],
-        'request_comment': arguments['comment'],
-        'request_ccs': arguments['cc_list'].split(','),
-        }
+                   'email': arguments['email'],
+                   'phone': arguments['phone'],
+                   'csrs': arguments['csr'],
+                   'request_comment': arguments['comment'],
+                   'request_ccs': arguments['cc_list'].split(',')}
     if 'vo' in arguments:
         params_list['vo'] = arguments['vo']
     params = urllib.urlencode(params_list)
@@ -318,7 +303,8 @@ def connect(arguments):
         print 'Succesfully submitted'
         print 'Request Id#: %s' % ticket
     else:
-        raise UnexpectedBehaviourEception("Unexpected Behavior encountered\nData received is %s" %data)
+        raise ExceptionDefinitions.UnexpectedBehaviourException("Unexpected Behavior encountered\nData received is %s" %
+                                                                data)
     return
 
 
@@ -341,7 +327,7 @@ if __name__ == '__main__':
                             'emailAddress': arguments['email'],
                             'alt_names': arguments['alt_names']}
 
-            if (arguments['certdir'] != "./"):
+            if arguments['certdir'] != "./":
                 cwd = os.getcwd()
 
             if cwd != None:
@@ -362,9 +348,9 @@ if __name__ == '__main__':
                                                      .replace('-----END CERTIFICATE REQUEST-----\n', '')
             arguments.update({'csr': csr})
             capi = ConnectAPI.ConnectAPI()
-            id = capi.request_unauthenticated(**arguments)
-            print 'Request Id#: %s' % id
-            arguments.update({'id':id})
+            reqid = capi.request_unauthenticated(**arguments)
+            print 'Request Id#: %s' % reqid
+            arguments.update({'id': reqid})
 
     except EOFError, e:
         print_exception_message(e)
@@ -386,21 +372,21 @@ if __name__ == '__main__':
         print_exception_message(e)
     except httplib.HTTPException, e:
         charlimit_textwrap('Connection to %s failed: %s' % (arguments['requrl'], repr(e)))
-    except Exception_500response, e:
+    except ExceptionDefinitions.Exception_500response, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
         sys.exit(1)
-    except FileNotFoundException, e:
+    except ExceptionDefinitions.FileNotFoundException, e:
         charlimit_textwrap(e.message + ':' + e.filename)
         sys.exit(1)
     except ValueError, e:
         print_exception_message(e)
         sys.exit(1)
-    except NotOKException, e:
+    except ExceptionDefinitions.NotOKException, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
         sys.exit(1)
-    except CertificateMismatchException, e:
+    except ExceptionDefinitions.CertificateMismatchException, e:
         print 'The number of requests made was ', e.request_num
         print 'The number of certificates received is ', e.retrieve_num
         charlimit_textwrap(e.message)
@@ -408,19 +394,19 @@ if __name__ == '__main__':
     except EOFError, e:
         print_exception_message(e)
         sys.exit(1)
-    except BadCertificateException, e:
+    except ExceptionDefinitions.BadCertificateException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
-    except BadPassphraseException, e:
+    except ExceptionDefinitions.BadPassphraseException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
-    except HandshakeFailureException, e:
+    except ExceptionDefinitions.HandshakeFailureException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
-    except UnexpectedBehaviourException, e:
+    except ExceptionDefinitions.UnexpectedBehaviourException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
-    except InvalidOptionException, e:
+    except ExceptionDefinitions.InvalidOptionException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
     except IOError, e:

--- a/osgpkitools/osg-cert-request
+++ b/osgpkitools/osg-cert-request
@@ -93,7 +93,7 @@ def parse_args():
         default='',
         )
     parser.add_option(
-        '-t',
+        '-H',
         '--hostname',
         action='store',
         dest='hostname',
@@ -133,6 +133,14 @@ def parse_args():
         dest='phone',
         help='Phone number of user receiving certificate',
         metavar='PHONE',
+        )
+    parser.add_option(
+        '-t',
+        '--timeout',
+        action='store',
+        dest='timeout',
+        help='Specify the timeout in minutes',
+        default=5,
         )
     parser.add_option(
         '-T',
@@ -179,7 +187,7 @@ def parse_args():
     if not args.email:
         parser.error('-e/--email argument required')
     if not args.hostname and not args.csr:
-        parser.error('-t/--hostname or -c/--csr argument required')
+        parser.error('-H/--hostname or -c/--csr argument required')
     if args.hostname and args.csr:
         parser.error('Both -t/--hostname and -c/--csr arguments specified. Choose one')
 
@@ -218,6 +226,15 @@ def parse_args():
         raise FileNotFoundException(args.csr,
                                     'The file %s does not exist'
                                     % args.csr)
+
+    try:
+        timeout = int(args.timeout)
+        if not timeout >= 0:
+            charlimit_textwrap('Your timeout value cannot be a negative integer.\n')
+            raise ValueError
+    except ValueError:
+        raise ValueError('Invalid timeout value. Please enter a non-negative integer value.\n')
+
     if args.write_directory:
         if args.write_directory[-1] != '/':
             args.write_directory = args.write_directory + '/'
@@ -242,6 +259,8 @@ def parse_args():
         arguments.update({'comment': comment})
     if vars().has_key('pem_filename'):
         arguments.update({'pem_filename': pem_filename})
+    arguments.update({'timeout': timeout})
+    print 'The timeout is set to %s' % arguments['timeout']
     arguments.update({'email': email})
     arguments.update({'name': name})
     arguments.update({'phone': phone})
@@ -307,6 +326,7 @@ if __name__ == '__main__':
     try:
         os.umask(0177)
         arguments = parse_args()
+        OSGPKIUtils.start_timeout_clock(arguments['timeout']*60)
         # The two modes in which the script is run are
         # 1. The user doesn't provide a csr:
         # Here we generate a private key for the user and also a
@@ -369,12 +389,6 @@ if __name__ == '__main__':
     except Exception_500response, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
-        sys.exit(1)
-    except TimeoutException, e:
-        charlimit_textwrap('Timeout reached in %s minutes. This script will now exit.'
-                            % e.timeout)
-        charlimit_textwrap(' You can open goc ticket to track this issue by going to https://ticket.grid.iu.edu\n'
-                           )
         sys.exit(1)
     except FileNotFoundException, e:
         charlimit_textwrap(e.message + ':' + e.filename)

--- a/osgpkitools/osg-cert-retrieve
+++ b/osgpkitools/osg-cert-retrieve
@@ -235,6 +235,7 @@ if __name__ == '__main__':
     try:
         os.umask(0177)
         arguments = parse_args()
+        OSGPKIUtils.start_timeout_clock(arguments['timeout'])
         path = os.getcwd()
         check_permissions(path)
         capi = ConnectAPI.ConnectAPI()
@@ -273,12 +274,6 @@ if __name__ == '__main__':
     except Exception_500response, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
-        sys.exit(1)
-    except TimeoutException, e:
-        charlimit_textwrap('Timeout reached in %s minutes. This script will now exit.'
-                            % e.timeout)
-        charlimit_textwrap(' You can open goc ticket to track this issue by going to https://ticket.grid.iu.edu\n'
-                           )
         sys.exit(1)
     except FileWriteException, e:
         charlimit_textwrap(e.message)

--- a/osgpkitools/osg-cert-retrieve
+++ b/osgpkitools/osg-cert-retrieve
@@ -16,42 +16,26 @@ This script checks to see if the output file exists and prompts the
 user if it does.
 """
 
-import urllib
 import httplib
-import sys
-import ConfigParser
-from optparse import OptionParser
-import simplejson
-import time
-import re
 import os
-import textwrap
-import traceback
-import subprocess
+from optparse import OptionParser
 from ssl import SSLError
+import subprocess
+import sys
 import tempfile
 
-from osgpkitools import OSGPKIUtils
 from osgpkitools import ConnectAPI
+from osgpkitools import OSGPKIUtils
+from osgpkitools import ExceptionDefinitions
 from osgpkitools.OSGPKIUtils import charlimit_textwrap
 from osgpkitools.OSGPKIUtils import CreateOIMConfig
 from osgpkitools.OSGPKIUtils import extractEEC
 from osgpkitools.OSGPKIUtils import extractHostname
-from osgpkitools.OSGPKIUtils import check_failed_response
-from osgpkitools.OSGPKIUtils import check_response_500
-from osgpkitools.OSGPKIUtils import print_failure_reason_exit
-from osgpkitools.OSGPKIUtils import check_for_pending
 from osgpkitools.OSGPKIUtils import check_permissions
 from osgpkitools.OSGPKIUtils import version_info
 from osgpkitools.OSGPKIUtils import find_existing_file_count
-from osgpkitools.OSGPKIUtils import handle_empty_exceptions
 from osgpkitools.OSGPKIUtils import print_exception_message
 from osgpkitools.OSGPKIUtils import print_uncaught_exception
-
-from osgpkitools.ExceptionDefinitions import *
-
-
-
 
 # Set up Option Parser
 #
@@ -67,8 +51,7 @@ def parse_args():
         '--certfile',
         action='store',
         dest='certfile',
-        help='Specify the output filename for the retrieved user certificate\n. Default is ./hostcert.pem'
-            ,
+        help='Specify the output filename for the retrieved user certificate\n. Default is ./hostcert.pem',
         metavar='ID',
         default='hostcert.pem',
         )
@@ -137,19 +120,17 @@ def parse_args():
     else:
         parser.error("Wrong number of arguments (%s of 1): %s"
                      % (num_args, ', '.join(str(value) for value in values)))
-    
+
     if args.id:
         charlimit_textwrap("The '-i' flag is deprecated and no longer needed when specifying a request ID.")
 
     try:
         timeout = int(args.timeout)
         if not timeout >= 0:
-            raise ValidationException('Your timeout value cannot be a negative integer.\nExiting now'
-                    )
-    except ValueError, e:
-        charlimit_textwrap('Invalid timeout value. Please enter a non-negative integer.\n'
-                           )
-        raise e
+            raise ExceptionDefinitions.ValidationException('Your timeout value cannot be a negative integer.')
+    except ValueError:
+        raise ExceptionDefinitions.ValidationException('Invalid timeout value. Please enter a non-negative integer.')
+
     print 'Using timeout of %d minutes' % timeout
 
     pem_filename = args.certfile
@@ -180,9 +161,8 @@ def parse_args():
 
     if vars().has_key('pem_filename'):
         arguments.update({'pem_filename': pem_filename})
-    if vars().has_key('timeout'):
-        arguments.update({'timeout': timeout})
 
+    arguments.update({'timeout': timeout})
     arguments.update({'id': reqid})
     arguments.update({'filetype': filetype})
     arguments.update({'fileext': fileext})
@@ -196,7 +176,7 @@ def write_certificate(pkcs7raw):
     """Separating the writing logic for user certificate and process the pkcs7raw string."""
     temp_filename = tempfile.NamedTemporaryFile()
     cwd = None
-    if (arguments['certdir'] != "./"):
+    if arguments['certdir'] != "./":
         cwd = os.getcwd()
     try:
         temp_filename.write(pkcs7raw)
@@ -223,11 +203,11 @@ def write_certificate(pkcs7raw):
         if cwd != None:
             os.chdir(cwd)
     except OSError, e:
-        charlimit_textwrap('You may not have permission to write on the file system. \nPlease report the bug to goc@opensciencegrid.org.'
-                           )
+        charlimit_textwrap('You may not have permission to write on the file system.\n' +
+                           'Please report the bug to goc@opensciencegrid.org.')
         raise e
     charlimit_textwrap('Certificate written to %s%s \n'
-                       %( arguments['certdir'],arguments['pem_filename']))
+                       % (arguments['certdir'], arguments['pem_filename']))
     return
 
 
@@ -241,20 +221,18 @@ if __name__ == '__main__':
         capi = ConnectAPI.ConnectAPI()
         print 'Connecting server to retrieve certificate...'
         pkcs7raw = capi.retrieve_unauthenticated(**arguments)
-        if(os.path.exists(arguments['pem_filename'])):
+        if os.path.exists(arguments['pem_filename']):
             pem_filename = arguments['pem_filename']
             temp_name = pem_filename.split("/")[-1].split(".")[-2]
             pem_filename_old = temp_name + "-old.pem"
             subprocess.call(['mv', pem_filename, pem_filename_old])
             charlimit_textwrap("Moving existing file %s to %s "
-                               %(arguments['pem_filename'] ,pem_filename_old))
+                               % (arguments['pem_filename'], pem_filename_old))
         new_file_name = find_existing_file_count(arguments['pem_filename'])
         if new_file_name != arguments['pem_filename']:
-            subprocess.call([
-            'mv',
-            arguments['pem_filename'],
-            new_file_name
-            ])
+            subprocess.call(['mv',
+                             arguments['pem_filename'],
+                             new_file_name])
             print 'Moving existing file ' + arguments['pem_filename'] + ' to ' + new_file_name
         write_certificate(pkcs7raw)
 
@@ -271,15 +249,15 @@ if __name__ == '__main__':
     except SSLError, e:
         print_exception_message(e)
         sys.exit('Please check for valid certificate.\n')
-    except Exception_500response, e:
+    except ExceptionDefinitions.Exception_500response, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
         sys.exit(1)
-    except FileWriteException, e:
+    except ExceptionDefinitions.FileWriteException, e:
         charlimit_textwrap(e.message)
         charlimit_textwrap("The script will exit now\n")
         sys.exit(1)
-    except FileNotFoundException, e:
+    except ExceptionDefinitions.FileNotFoundException, e:
         charlimit_textwrap(e.message + ':' + e.filename)
         sys.exit(1)
     except ValueError, e:
@@ -288,28 +266,27 @@ if __name__ == '__main__':
     except KeyError, e:
         print_exception_message(e)
     except httplib.HTTPException, e:
-        charlimit_textwrap('Connection to %s failed: %s' % (returl, e))
-    except NotOKException, e:
+        charlimit_textwrap('Connection to %s failed: %s' % (arguments['returl'], e))
+    except ExceptionDefinitions.NotOKException, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
         sys.exit(1)
-    except ValidationException, e:
+    except ExceptionDefinitions.ValidationException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
-    except InvalidOptionException, e:
+    except ExceptionDefinitions.InvalidOptionException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
-    except NotApprovedException, e:
+    except ExceptionDefinitions.NotApprovedException, e:
         charlimit_textwrap(e.message)
     except OSError, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
-    except UnexpectedBehaviourException, e:
+    except ExceptionDefinitions.UnexpectedBehaviourException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
     except Exception, e:
         print_uncaught_exception()
-        charlimit_textwrap('Uncaught Exception : Please report the bug to goc@opensciencegrid.org.'
-                           )
+        charlimit_textwrap('Uncaught Exception : Please report the bug to goc@opensciencegrid.org.')
         sys.exit(1)
     sys.exit(0)

--- a/osgpkitools/osg-cert-revoke
+++ b/osgpkitools/osg-cert-revoke
@@ -3,7 +3,7 @@
 import sys
 import urllib
 import httplib
-import M2Crypto
+from M2Crypto import httpslib, SSL
 import simplejson
 import traceback
 import os
@@ -228,10 +228,10 @@ def connect_revoke(**arguments):
     headers = {'Content-type': arguments['content_type'],
                'User-Agent': 'OIMGridAPIClient/0.1 (OIM Grid API)'}
 
-    charlimit_textwrap('Contacting Server to revoke the %s certificate \n' % revoke_text['cert_type'])
+    charlimit_textwrap('Contacting Server to revoke the %s certificate...' % revoke_text['cert_type'])
 
-    conn = M2Crypto.httpslib.HTTPSConnection(arguments['hostsec'],
-                                             ssl_context=arguments['ssl_context'])
+    conn = httpslib.HTTPSConnection(arguments['hostsec'],
+                                    ssl_context=arguments['ssl_context'])
     try:
         conn.request('POST', arguments[url], params, headers)
         response = conn.getresponse()
@@ -239,8 +239,10 @@ def connect_revoke(**arguments):
         charlimit_textwrap('Connection to %s failed: %s'
                            % (arguments[url], repr(e)))
         raise e
-    except AttributeError, e:
-        raise e
+    except SSL.SSLError, exc:
+        charlimit_textwrap("="*80 + "ERROR: There was an issue with your credentials!")
+        charlimit_textwrap(exc.message)
+        sys.exit(1)
     check_response_500(response)
     if not 'OK' in response.reason:
         raise ExceptionDefinitions.NotOKException(response.status, response.message)

--- a/osgpkitools/osg-cert-revoke
+++ b/osgpkitools/osg-cert-revoke
@@ -9,14 +9,13 @@ import traceback
 import os
 from optparse import OptionParser
 
+from osgpkitools import ExceptionDefinitions
 from osgpkitools.OSGPKIUtils import charlimit_textwrap
 from osgpkitools.OSGPKIUtils import CreateOIMConfig
 from osgpkitools.OSGPKIUtils import print_exception_message
-from osgpkitools.OSGPKIUtils import print_failure_reason_exit
 from osgpkitools.OSGPKIUtils import check_response_500
 from osgpkitools.OSGPKIUtils import get_ssl_context
 from osgpkitools.OSGPKIUtils import version_info
-from osgpkitools.ExceptionDefinitions import *
 
 def parse_args():
     """This function parses all the arguments, validates them and then
@@ -90,8 +89,7 @@ def parse_args():
         '--message',
         action='store',
         dest='message',
-        help="Specify the reason for certificate revocation [deprecated]"
-            ,
+        help="Specify the reason for certificate revocation [deprecated]",
         default=None,
         metavar='REASON',
         )
@@ -115,7 +113,7 @@ def parse_args():
         charlimit_textwrap("The '-i' flag is deprecated and no longer needed when specifying a request ID.")
     if args.message:
         charlimit_textwrap("The '-m' flag is deprecated and no longer needed when specifying a message.")
-        
+
     # Get command line arguments
     num_args = len(values)
     if num_args >= 1 and num_args <= 2:
@@ -143,36 +141,36 @@ def parse_args():
             userprivkey = os.environ['X509_USER_KEY']
         except:
             if os.path.exists(str(os.environ['HOME'])
-                                + '/.globus/userkey.pem'):
+                              + '/.globus/userkey.pem'):
                 userprivkey = str(os.environ['HOME']) \
                     + '/.globus/userkey.pem'
             else:
-                raise FileNotFoundException('Key file',
-                        'Could not locate the private key file')
+                raise ExceptionDefinitions.FileNotFoundException('Key file',
+                                                                 'Could not locate the private key file')
     else:
         userprivkey = args.userprivkey
 
     if not os.path.exists(userprivkey):
-        raise FileNotFoundException(userprivkey, 'Could not locate the private key file')
+        raise ExceptionDefinitions.FileNotFoundException(userprivkey, 'Could not locate the private key file')
     if args.usercert is None:
         try:
             usercert = os.environ['X509_USER_CERT']
-        except:
+        except KeyError:
             usercert = str(os.environ['HOME']) + '/.globus/usercert.pem'
             if os.path.exists(str(os.environ['HOME'])
                               + '/.globus/usercert.pem'):
                 usercert = str(os.environ['HOME']) \
                     + '/.globus/usercert.pem'
             else:
-                raise FileNotFoundException('Certificate File',
-                        'Could not locate the certificate file')
+                raise ExceptionDefinitions.FileNotFoundException('Certificate File',
+                                                                 'Could not locate the certificate file')
     else:
         usercert = args.usercert
 
     if not os.path.exists(usercert):
-        raise FileNotFoundException(usercert, 'Could not locate the certificate file')
+        raise ExceptionDefinitions.FileNotFoundException(usercert, 'Could not locate the certificate file')
 
-    arguments.update({'certid': args.certid})    
+    arguments.update({'certid': args.certid})
     arguments.update({'id': reqid})
     arguments.update({'message': args.message})
     arguments.update({'user': args.user})
@@ -208,7 +206,7 @@ def connect_revoke(**arguments):
     OUTPUT:
         Returns nothing, printing if the revocation was successful or not on the terminal.
     """
-    
+
     revoke_text = {}
     if arguments['user']:
         id_type = 'user_request_id'
@@ -218,20 +216,20 @@ def connect_revoke(**arguments):
         id_type = 'host_request_id'
         url = 'revurl'
         revoke_text = {'cert_type': 'host'}
-        
+
     if arguments['certid']:
         id_type = 'serial_id'
         revoke_text['id_type'] = 'certificate'
     else:
         revoke_text['id_type'] = 'request'
-        
+
     params = urllib.urlencode({id_type: arguments['id'],
                                'request_comment':arguments['message']})
     headers = {'Content-type': arguments['content_type'],
                'User-Agent': 'OIMGridAPIClient/0.1 (OIM Grid API)'}
 
     charlimit_textwrap('Contacting Server to revoke the %s certificate \n' % revoke_text['cert_type'])
-    
+
     conn = M2Crypto.httpslib.HTTPSConnection(arguments['hostsec'],
                                              ssl_context=arguments['ssl_context'])
     try:
@@ -245,13 +243,13 @@ def connect_revoke(**arguments):
         raise e
     check_response_500(response)
     if not 'OK' in response.reason:
-        raise NotOKException(response.status, response.message)
+        raise ExceptionDefinitions.NotOKException(response.status, response.message)
     data = response.read()
     conn.close()
 
-    if (simplejson.loads(data)['status'] == 'OK'):
-            charlimit_textwrap("Successfully revoked %s certificate with %s ID: %s" %
-                               (revoke_text['cert_type'], revoke_text['id_type'], str(arguments['id'])))
+    if simplejson.loads(data)['status'] == 'OK':
+        charlimit_textwrap("Successfully revoked %s certificate with %s ID: %s" %
+                           (revoke_text['cert_type'], revoke_text['id_type'], str(arguments['id'])))
     else:
         charlimit_textwrap("Failure, could not revoke certificate.")
         charlimit_textwrap(simplejson.loads(data)['detail'])
@@ -264,16 +262,16 @@ if __name__ == "__main__":
         arguments.update({'ssl_context': ssl_context})
         connect_revoke(**arguments)
 
-    except FileNotFoundException, e:
+    except ExceptionDefinitions.FileNotFoundException, e:
         print_exception_message(e)
 
-    except BadCertificateException, e:
+    except ExceptionDefinitions.BadCertificateException, e:
         print_exception_message(e)
         sys.exit(1)
-    except HandshakeFailureException, e:
+    except ExceptionDefinitions.HandshakeFailureException, e:
         print_exception_message(e)
         sys.exit(1)
-    except BadPassphraseException, e:
+    except ExceptionDefinitions.BadPassphraseException, e:
         charlimit_textwrap("Invalid passphrase entered, please try running the script again.")
         sys.exit(1)
     except KeyError, e:
@@ -285,11 +283,11 @@ if __name__ == "__main__":
     except AttributeError, e:
         print_exception_message(e)
         sys.exit(1)
-    except NotOKException, e:
+    except ExceptionDefinitions.NotOKException, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
         sys.exit(1)
-    except SystemExit: 
+    except SystemExit:
         # We need to specifically catch sys.exit() so that it doesn't hit the catchall Exception below and
         # print a confusing message for the user (SOFTWARE-1584)
         raise

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -14,7 +14,6 @@ This script works in two modes:
 import httplib
 import sys
 import simplejson
-import re
 import os
 import M2Crypto
 from optparse import OptionParser, OptionGroup
@@ -22,6 +21,8 @@ import subprocess
 from ssl import SSLError
 import tempfile
 
+from osgpkitools import ConnectAPI
+from osgpkitools import ExceptionDefinitions
 from osgpkitools import OSGPKIUtils
 from osgpkitools.OSGPKIUtils import CreateOIMConfig
 from osgpkitools.OSGPKIUtils import extractHostname
@@ -32,14 +33,11 @@ from osgpkitools.OSGPKIUtils import check_failed_response
 from osgpkitools.OSGPKIUtils import check_for_pending
 from osgpkitools.OSGPKIUtils import version_info
 from osgpkitools.OSGPKIUtils import check_permissions
-from osgpkitools.OSGPKIUtils import find_existing_file_count
 from osgpkitools.OSGPKIUtils import charlimit_textwrap
 from osgpkitools.OSGPKIUtils import print_exception_message
+from osgpkitools.OSGPKIUtils import print_failure_reason_exit
 from osgpkitools.OSGPKIUtils import print_uncaught_exception
 from osgpkitools.OSGPKIUtils import get_ssl_context
-from osgpkitools.ExceptionDefinitions import *
-from osgpkitools import ConnectAPI
-
 
 # Set up Option Parser
 #
@@ -172,7 +170,7 @@ or specify from a file using -f/--hostfile.''')
 
     if not args.hostname:
         if args.hostfile is None:
-            raise InsufficientArgumentException("InsufficientArgumentException: " + \
+            raise ExceptionDefinitions.InsufficientArgumentException("InsufficientArgumentException: " + \
                                                 "Please provide hostname(-H) or file name containing hosts(-f)\n")
         else:
             hostfile = args.hostfile
@@ -203,14 +201,14 @@ or specify from a file using -f/--hostfile.''')
                 userprivkey = str(os.environ['HOME']) \
                     + '/.globus/userkey.pem'
             else:
-                raise FileNotFoundException('Key file', 'Could not locate the private key file')
+                raise ExceptionDefinitions.FileNotFoundException('Key file', 'Could not locate the private key file')
     else:
         userprivkey = args.userprivkey
 
     if os.path.exists(userprivkey):
         pass
     else:
-        raise FileNotFoundException(userprivkey, 'Could not locate the private key file')
+        raise ExceptionDefinitions.FileNotFoundException(userprivkey, 'Could not locate the private key file')
     if args.usercert is None:
         try:
             usercert = os.environ['X509_USER_CERT']
@@ -221,20 +219,20 @@ or specify from a file using -f/--hostfile.''')
                 usercert = str(os.environ['HOME']) \
                     + '/.globus/usercert.pem'
             else:
-                raise FileNotFoundException('Certificate File', 'Could not locate the certificate file')
+                raise ExceptionDefinitions.FileNotFoundException('Certificate File', 'Could not locate the certificate file')
     else:
         usercert = args.usercert
 
     if os.path.exists(usercert):
         pass
     else:
-        raise FileNotFoundException(usercert, 'Could not locate the certificate file')
+        raise ExceptionDefinitions.FileNotFoundException(usercert, 'Could not locate the certificate file')
 
     if not args.hostname:
         if os.path.exists(hostfile):
             pass
         else:
-            raise FileNotFoundException(hostfile, 'Could not locate the hostfile')
+            raise ExceptionDefinitions.FileNotFoundException(hostfile, 'Could not locate the hostfile')
     if args.test:
         OIM = True
     else:
@@ -310,9 +308,8 @@ def write_certificate(**arguments):
         os.getcwd()
     except OSError, e:
         charlimit_textwrap('''The directory %s does not exist or you cannot access the directory
-    .Please report the bug to goc@opensciencegrid.org.a
-    %s''',
-                           arguments['certdir'], e)
+    . Please report the bug to goc@opensciencegrid.org:
+    %s''' % (arguments['certdir'], e))
         raise OSError
     hostname = arguments['hostname']
     eecString = arguments['eecString']
@@ -353,7 +350,7 @@ def process_pkcs7(pkcs7, num_requests, **arguments):
         cert_num = cert_num + 1
 
     if cert_num != num_requests:
-        raise CertificateMismatchException(num_requests, cert_num, 'Request and certificate received mismatch')
+        raise ExceptionDefinitions.CertificateMismatchException(num_requests, cert_num, 'Request and certificate received mismatch')
     return
 
 
@@ -396,7 +393,7 @@ def check_quota_limit(request_count, arguments):
 
     except Exception, e:
         if "sslv3 alert bad certificate" in e:
-            raise BadCertificateException("Error connecting to server: %s.\n" + \
+            raise ExceptionDefinitions.BadCertificateException("Error connecting to server: %s.\n" + \
                                           "Your certificate is not trusted by the server" % e)
         else:
             print e.__class__.__name__
@@ -453,16 +450,12 @@ def process_csr(num_requests, bulk_csr, **arguments):
     except KeyError, e:
         raise
     except httplib.HTTPException, e:
-        charlimit_textwrap('Connection to %s failed : %s' % (requrl, e))
-        raise e
-    except Exception_500response, e:
-        raise e
-    except NotOKException, e:
+        charlimit_textwrap('Connection to %s failed : %s' % (arguments['requrl'], e))
         raise e
 
     except Exception, e:
         if 'sslv3 alert bad certificate' in e:
-            raise BadCertificateException("Error connecting to server: %s.\n" + \
+            raise ExceptionDefinitions.BadCertificateException("Error connecting to server: %s.\n" + \
                                           "Your certificate is not trusted by the server" % e)
         else:
             raise
@@ -479,20 +472,12 @@ def process_csr(num_requests, bulk_csr, **arguments):
         pkcs7raw = capi.retrieve_authenticated(**arguments)
         process_pkcs7(pkcs7raw, num_requests, **arguments)
 
-    except KeyError, e:
-        raise
     except httplib.HTTPException, e:
-        charlimit_textwrap('Connection to %s failed: %s'% (newrequrl, e))
-        raise e
-    except Exception_500response, e:
-        raise e
-    except NotOKException, e:
-        raise e
-    except CertificateMismatchException, e:
+        charlimit_textwrap('Connection to %s failed: %s'% (arguments['newrequrl'], e))
         raise e
     except Exception, e:
         if 'sslv3 alert bad certificate' in e:
-            raise BadCertificateException("Error connecting to server: %s.\n" + \
+            raise ExceptionDefinitions.BadCertificateException("Error connecting to server: %s.\n" + \
                                           "Your certificate is not trusted by the server" % e)
         else:
             raise
@@ -505,10 +490,8 @@ def process_single_host_mode(**arguments):
     num_requests = 1
     config_items = {}
 
-    if check_quota_limit(num_requests, arguments):
-        pass
-    else:
-        raise QuotaException('Your request would exceed your quota. Aborting')
+    if not check_quota_limit(num_requests, arguments):
+        raise ExceptionDefinitions.QuotaException('Your request would exceed your quota. Aborting')
     hostname = arguments['hostname'].strip()
     config_items.update({'CN': hostname, 'alt_names': arguments['alt_names']})
     charlimit_textwrap('Beginning request process for %s' % hostname)
@@ -533,10 +516,8 @@ def process_hostfile_mode(**arguments):
     hosts = hosts_file.readlines()
     hosts_file.close()
 
-    if check_quota_limit(request_count, arguments):
-        pass
-    else:
-        raise QuotaException('Your request would exceed your quota. Aborting')
+    if not check_quota_limit(request_count, arguments):
+        raise ExceptionDefinitions.QuotaException('Your request would exceed your quota. Aborting')
     for line in hosts:
         line = line.strip()
         if line != '' and line not in host_set:
@@ -586,7 +567,7 @@ if __name__ == '__main__':
     except OSError, e:
         print_exception_message(e)
         sys.exit(1)
-    except Exception_500response, e:
+    except ExceptionDefinitions.Exception_500response, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
         sys.exit(1)
@@ -596,21 +577,21 @@ if __name__ == '__main__':
     except httplib.HTTPException, e:
         print_exception_message(e)
         charlimit_textwrap('Connection failed: %s' % (e))
-    except FileWriteException, e:
+    except ExceptionDefinitions.FileWriteException, e:
         charlimit_textwrap(e.message)
         charlimit_textwrap("The script will exit now\n")
         sys.exit(1)
-    except FileNotFoundException, e:
+    except ExceptionDefinitions.FileNotFoundException, e:
         charlimit_textwrap(e.message + ':' + e.filename)
         sys.exit(1)
     except ValueError, e:
         print_exception_message(e)
         sys.exit(1)
-    except NotOKException, e:
+    except ExceptionDefinitions.NotOKException, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
         sys.exit(1)
-    except CertificateMismatchException, e:
+    except ExceptionDefinitions.CertificateMismatchException, e:
         print 'The number of requests made was ', e.request_num
         print 'The number of certificates received is ', e.retrieve_num
         charlimit_textwrap(e.message)
@@ -618,25 +599,25 @@ if __name__ == '__main__':
     except EOFError, e:
         print_exception_message(e)
         sys.exit(1)
-    except BadCertificateException, e:
+    except ExceptionDefinitions.BadCertificateException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
-    except BadPassphraseException, e:
+    except ExceptionDefinitions.BadPassphraseException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
-    except HandshakeFailureException, e:
+    except ExceptionDefinitions.HandshakeFailureException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
-    except QuotaException, e:
+    except ExceptionDefinitions.QuotaException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
     except M2Crypto.SSL.SSLError, e:
         print_exception_message(e)
         sys.exit(1)
-    except UnexpectedBehaviourException, e:
+    except ExceptionDefinitions.UnexpectedBehaviourException, e:
         print_exception_message(e)
         sys.exit(1)
-    except InsufficientArgumentException, e:
+    except ExceptionDefinitions.InsufficientArgumentException, e:
         # I agree with mat on JIRA Software 1072 on that if a user enters
         # the script without options, there is no bug and shouldn't be
         # reported to goc. Hence bypassing call to print exception message

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -585,8 +585,8 @@ if __name__ == '__main__':
     except SSLError, e:
         print_exception_message(e)
         sys.exit('Please check for valid certificate.\n')
-    except KeyboardInterrupt, k:
-        print_exception_message(e)
+    except KeyboardInterrupt, exc:
+        print_exception_message(exc)
         sys.exit('''Interrupted by user\n''')
     except OSError, e:
         print_exception_message(e)

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -182,7 +182,7 @@ or specify from a file using -f/--hostfile.''')
     try:
         timeout = int(args.timeout)
         if not timeout >= 0:
-            charlimit_textwrap('Your timeout value cannot be a negative integer.\nExiting now')
+            charlimit_textwrap('Your timeout value cannot be a negative integer.\n')
             raise ValueError
     except ValueError:
         raise ValueError('Invalid timeout value. Please enter a non-negative integer value.\n')
@@ -250,15 +250,8 @@ or specify from a file using -f/--hostfile.''')
         arguments.update({'values': values})
     if vars().has_key('hostname'):
         arguments.update({'hostname': hostname})
-    if vars().has_key('domain'):
-        arguments.update({'domain': domain})
-    if vars().has_key('outkeyfile'):
-        arguments.update({'outkeyfile': outkeyfile})
-    if vars().has_key('timeout'):
-        arguments.update({'timeout': timeout})
-        print 'The timeout is set to %s' % arguments['timeout']
-    if vars().has_key('num_requests'):
-        arguments.update({'num_requests': num_requests})
+    arguments.update({'timeout': timeout})
+    print 'The timeout is set to %s' % arguments['timeout']
     arguments.update({'alt_names': args.alt_names})
     arguments.update({'usercert': usercert})
     arguments.update({'userprivkey': userprivkey})
@@ -426,7 +419,7 @@ def check_quota_limit(request_count, arguments):
         check_response_500(response)
         data = response.read()
         conn.close()
-        iterations = check_for_pending(data, iterations, **arguments)
+        iterations = check_for_pending(iterations)
     check_failed_response(data)
     global_hostcert_year_max = \
         simplejson.loads(data)['global_hostcert_year_max']
@@ -566,9 +559,12 @@ if __name__ == '__main__':
     try:
         os.umask(0177)
         arguments = parse_args()
+        OSGPKIUtils.start_timeout_clock(arguments['timeout']*60)
         check_permissions(arguments['certdir'])
         ssl_context = get_ssl_context(**arguments)
         arguments.update({'ssl_context':ssl_context})
+
+        # Request cert(s)
         if not arguments.has_key('hostname'):
             process_hostfile_mode(**arguments)
         else:
@@ -593,10 +589,6 @@ if __name__ == '__main__':
     except Exception_500response, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
-        sys.exit(1)
-    except TimeoutException, e:
-        charlimit_textwrap('Timeout reached in %s minutes. This script will now exit.' % e.timeout)
-        charlimit_textwrap(' You can open goc ticket to track this issue by going to https://ticket.grid.iu.edu\n')
         sys.exit(1)
     except KeyError, e:
         print_exception_message(e)

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -574,9 +574,11 @@ if __name__ == '__main__':
     except KeyError, e:
         print_exception_message(e)
         charlimit_textwrap('Key %s not found' % e)
+        sys.exit(1)
     except httplib.HTTPException, e:
         print_exception_message(e)
         charlimit_textwrap('Connection failed: %s' % (e))
+        sys.exit(1)
     except ExceptionDefinitions.FileWriteException, e:
         charlimit_textwrap(e.message)
         charlimit_textwrap("The script will exit now\n")

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -186,7 +186,6 @@ or specify from a file using -f/--hostfile.''')
             raise ValueError
     except ValueError:
         raise ValueError('Invalid timeout value. Please enter a non-negative integer value.\n')
-    print 'Using timeout of %d minutes' % timeout
 
     if args.write_directory:
         certdir = args.write_directory

--- a/osgpkitools/osg-user-cert-renew
+++ b/osgpkitools/osg-user-cert-renew
@@ -14,6 +14,8 @@ import M2Crypto
 from optparse import OptionParser
 from ssl import SSLError
 
+from osgpkitools import OSGPKIUtils
+from osgpkitools import ExceptionDefinitions
 from osgpkitools.OSGPKIUtils import CreateOIMConfig
 from osgpkitools.OSGPKIUtils import get_ssl_context
 from osgpkitools.OSGPKIUtils import check_response_500
@@ -24,7 +26,6 @@ from osgpkitools.OSGPKIUtils import charlimit_textwrap
 from osgpkitools.OSGPKIUtils import print_exception_message
 from osgpkitools.OSGPKIUtils import print_uncaught_exception
 from osgpkitools.OSGPKIUtils import version_info
-from osgpkitools.ExceptionDefinitions import *
 
 
 
@@ -123,7 +124,7 @@ def parse_args():
                 userprivkey = ''
 
     if not os.path.exists(userprivkey):
-        raise FileNotFoundException(userprivkey, 'Could not locate the private key file')
+        raise ExceptionDefinitions.FileNotFoundException(userprivkey, 'Could not locate the private key file')
 
     if args.usercert:
         usercert = args.usercert
@@ -137,15 +138,15 @@ def parse_args():
                 usercert = ''
 
     if not os.path.exists(usercert):
-        raise FileNotFoundException(usercert, 'Could not locate the certificate file')
+        raise ExceptionDefinitions.FileNotFoundException(usercert, 'Could not locate the certificate file')
 
     # Check write directory existence and write permission
     try:
         if not os.access(args.write_directory, os.W_OK):
-            raise FileWriteException('Do not have write permissions to %s' % args.write_directory)
+            raise ExceptionDefinitions.FileWriteException('Do not have write permissions to %s' % args.write_directory)
     except OSError, e:
         if e.errno == errno.ENOENT:
-            raise FileNotFoundException(args.write_directory, 'Could not locate the output directory')
+            raise ExceptionDefinitions.FileNotFoundException(args.write_directory, 'Could not locate the output directory')
         else:
             raise
 
@@ -217,7 +218,7 @@ def connect_renew(**arguments):
     return_data = simplejson.loads(data)
     request_id = return_data['request_id']
     if not request_id:
-        raise UnexpectedBehaviourException("Request Id not found in data. Script will now exit")
+        raise ExceptionDefinitions.UnexpectedBehaviourException("Request Id not found in data. Script will now exit")
     arguments.update({'reqid': request_id})
     return arguments
 
@@ -309,8 +310,8 @@ def process_csr(**arguments):
         arguments = connect_renew(**arguments)
     except Exception, e:
         if 'sslv3 alert bad certificate' in e:
-            raise BadCertificateException('Error connecting to server: %s.\n' +
-                                          'Your certificate is not trusted by the server' % e)
+            raise ExceptionDefinitions.BadCertificateException('Error connecting to server: %s.\n' +
+                                                               'Your certificate is not trusted by the server' % e)
         else:
             print_uncaught_exception()
             raise
@@ -357,24 +358,24 @@ if __name__ == '__main__':
     except OSError, e:
         print_exception_message(e)
         sys.exit(1)
-    except Exception_500response, e:
+    except ExceptionDefinitions.Exception_500response, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
         sys.exit(1)
-    except FileNotFoundException, e:
+    except ExceptionDefinitions.FileNotFoundException, e:
         charlimit_textwrap(e.message + ':' + e.filename)
         sys.exit(1)
-    except FileWriteException, e:
+    except ExceptionDefinitions.FileWriteException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
     except ValueError, e:
         print_exception_message(e)
         sys.exit(1)
-    except NotOKException, e:
+    except ExceptionDefinitions.NotOKException, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
         sys.exit(1)
-    except CertificateMismatchException, e:
+    except ExceptionDefinitions.CertificateMismatchException, e:
         print 'The number of requests made was ', e.request_num
         print 'The number of certificates received is ', e.retrieve_num
         charlimit_textwrap(e.message)
@@ -382,22 +383,22 @@ if __name__ == '__main__':
     except EOFError, e:
         print_exception_message(e)
         sys.exit(1)
-    except BadCertificateException, e:
+    except ExceptionDefinitions.BadCertificateException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
-    except BadPassphraseException, e:
+    except ExceptionDefinitions.BadPassphraseException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
-    except HandshakeFailureException, e:
+    except ExceptionDefinitions.HandshakeFailureException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
-    except QuotaException, e:
+    except ExceptionDefinitions.QuotaException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
-    except UnexpectedBehaviourException, e:
+    except ExceptionDefinitions.UnexpectedBehaviourException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
-    except InsufficientArgumentException, e:
+    except ExceptionDefinitions.InsufficientArgumentException, e:
         charlimit_textwrap(e.message)
         sys.exit(1)
     except Exception, e:

--- a/osgpkitools/osg-user-cert-renew
+++ b/osgpkitools/osg-user-cert-renew
@@ -289,7 +289,7 @@ def connect_retrieve(**arguments):
             raise httplib.HTTPException
         check_response_500(response)
         json = response.read()
-        iterations = check_for_pending(json, iterations, **arguments)
+        iterations = check_for_pending(iterations)
     conn.close()
     check_failed_response(json)
     data = simplejson.loads(json)
@@ -337,6 +337,7 @@ if __name__ == '__main__':
     try:
         os.umask(0177)
         arguments = parse_args()
+        OSGPKIUtils.start_timeout_clock(arguments['timeout'])
         arguments['ssl_context'] = get_ssl_context(**arguments)
         arguments = extract_info(**arguments)
         process_renew(**arguments)
@@ -359,11 +360,6 @@ if __name__ == '__main__':
     except Exception_500response, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
-        sys.exit(1)
-    except TimeoutException, e:
-        charlimit_textwrap('Timeout reached in %s minutes. This script will now exit.' %
-                           e.timeout)
-        charlimit_textwrap(' You can open goc ticket to track this issue by going to https://ticket.grid.iu.edu\n')
         sys.exit(1)
     except FileNotFoundException, e:
         charlimit_textwrap(e.message + ':' + e.filename)

--- a/tests/CertRenewTests.py
+++ b/tests/CertRenewTests.py
@@ -3,7 +3,7 @@
 import re
 import unittest
 
-from pkiunittest import OIM, DOMAIN, test_env_setup, test_env_teardown
+from pkiunittest import OIM, test_env_setup, test_env_teardown
 
 class CertRenewTests(unittest.TestCase):
 
@@ -14,7 +14,7 @@ class CertRenewTests(unittest.TestCase):
     def tearDown(self):
         """Remove personal test dir"""
         test_env_teardown()
-    
+
     def test_help(self):
         """Test running with -h to get help"""
         rc, stdout, _, msg = OIM().user_renew('--help')
@@ -24,5 +24,4 @@ class CertRenewTests(unittest.TestCase):
     #TODO: Implement tests for actual renew functionality
 
 if __name__ == '__main__':
-    import unittest
     unittest.main()

--- a/tests/CertRetrieveTests.py
+++ b/tests/CertRetrieveTests.py
@@ -2,7 +2,7 @@
 
 import re
 import unittest
-from pkiunittest import OIM, DOMAIN, test_env_setup, test_env_teardown
+from pkiunittest import OIM, test_env_setup, test_env_teardown
 
 class CertRetrieveTests(unittest.TestCase):
 
@@ -19,6 +19,16 @@ class CertRetrieveTests(unittest.TestCase):
         rc, stdout, _, msg = OIM().retrieve('--help')
         self.assertEqual(rc, 0, "Bad return code when requesting help\n%s" % msg)
         self.assert_(re.search(r'[Uu]sage:', stdout), msg)
+
+    def test_timeout_bad_input(self):
+        """Ensure tool fails on negative int input"""
+        oim = OIM()
+        oim.reqid = '1' # avoid missing reqid argument check
+        rc, _, _, msg = oim.retrieve('--timeout', '-1')
+        self.assertEqual(rc, 1, 'Succeeded on negative int input\n%s' % msg)
+
+        rc, _, _, msg = oim.retrieve('--timeout', 'string')
+        self.assertEqual(rc, 1, 'Succeeded on string input\n%s' % msg)
 
     # TODO: Request cert, approve it (see osgpkiutils/ConnectAPI.py), and then retrieve it.
 

--- a/tests/CertRevokeTests.py
+++ b/tests/CertRevokeTests.py
@@ -13,19 +13,19 @@ class CertRevokeTests(unittest.TestCase):
     def tearDown(self):
         """Remove personal test dir"""
         test_env_teardown()
-    
+
     def test_help(self):
         """Test running with -h to get help"""
         rc, stdout, _, msg = OIM().revoke('--help')
-        self.assertEqual(rc, 0, "Bad return code when requesting help\n%s" % msg)        
+        self.assertEqual(rc, 0, "Bad return code when requesting help\n%s" % msg)
         self.assert_(re.search(r'[Uu]sage:', stdout), msg)
 
     def test_user_help(self):
         """Test running with -h to get help"""
         rc, stdout, _, msg = OIM().user_revoke('--help')
-        self.assertEqual(rc, 0, "Bad return code when requesting help\n%s" % msg)        
+        self.assertEqual(rc, 0, "Bad return code when requesting help\n%s" % msg)
         self.assert_(re.search(r'[Uu]sage:', stdout), msg)
-        
+
     def test_revoke(self):
         """Test basic revocation"""
         oim = OIM()

--- a/tests/GridadminCertRequestTests.py
+++ b/tests/GridadminCertRequestTests.py
@@ -55,8 +55,8 @@ class GridadminCertRequestTests(unittest.TestCase):
         second_san = 'test-san2.' + DOMAIN
         oim = OIM()
         rc, _, _, msg = oim.gridadmin_request('--hostname', hostname,
-                                                  '--altname', san,
-                                                  '--altname', second_san)
+                                              '--altname', san,
+                                              '--altname', second_san)
         self.assertEqual(rc, 0, "Failed to request certificate\n%s" % msg)
         oim.assertSans([[hostname, san, second_san]], msg)
 

--- a/tests/pkiunittest.py
+++ b/tests/pkiunittest.py
@@ -153,8 +153,6 @@ class OIM(object):
 
     def retrieve(self, *opts):
         """Run osg-cert-retrieve"""
-        if not self.reqid and '--help' not in opts:
-            raise CertFileError('Could not revoke cert due to missing request ID\n')
         args = list(opts + (self.reqid,))
         return run_python('osg-cert-retrieve', '--test',
                           '--directory', TEST_PATH,
@@ -166,8 +164,6 @@ class OIM(object):
 
     def revoke(self, *opts):
         """Run osg-cert-revoke"""
-        if not self.reqid and '--help' not in opts:
-            raise CertFileError('Could not revoke cert due to missing request ID\n')
         args = opts + ('--test',
                        '--cert', GA_CERT_PATH,
                        '--pkey', GA_KEY_PATH,
@@ -217,7 +213,7 @@ class OIM(object):
 
     @staticmethod
     def simple_pass_callback(verify):
-        """Callback for unlocking keys with passwords in plaintext for testing."""
+        """Callback for unlocking keys with passwords in plaintext."""
         return ''
 
     def assertNumCerts(self, num_expected_certs, msg):

--- a/tests/pkiunittest.py
+++ b/tests/pkiunittest.py
@@ -82,8 +82,8 @@ def run_command(cmd, env=None):
 def run_python(script, *args):
     '''Run osg-pki-tools script '''
     script_path = os.path.join(SCRIPTS_PATH, script)
-    full_cmd = (sys.executable, script_path) + args
-    return run_command(full_cmd, env=os.environ)
+    py_cmd = (sys.executable, script_path) + args
+    return run_command(py_cmd, env=os.environ)
 
 class OIM(object):
     """OIM and cert/key pair interface"""
@@ -175,7 +175,7 @@ class OIM(object):
         if not self.reqid and '--help' not in opts:
             raise CertFileError('Could not revoke cert due to missing request ID\n')
         args = opts + ('--test', self.reqid, 'osg-pki-tools unit test - user revoke')
-        cmd = (os.path.join(SCRIPTS_PATH, 'osg-user-cert-revoke'),) + args
+        cmd = ('/bin/sh', os.path.join(SCRIPTS_PATH, 'osg-user-cert-revoke'),) + args
         return run_command(cmd)
 
     @staticmethod


### PR DESCRIPTION
I know this is a big PR but working on `osg-pki-tools` can be a bit like [replacing a lightbulb](https://www.youtube.com/watch?v=d1CYncXkCv4). Here are the highlights:

* Basic pylint fixes: whitespaces, indentation, non-Pythonic formatting, etc (the bulk of the PR)
* Fix timeout option to respect tool runtime ([SOFTWARE-2258](https://jira.opensciencegrid.org/browse/SOFTWARE-2258))
* Added `-t/--timeout` to the tools that didn't have it. This caused a conflict in `osg-cert-request` with the `-t/--hostname` option so I changed that to `-H/--hostname` to match `osg-gridadmin-cert-request`. I could just as easily drop this change but common options across the tools really should be called the same way. I suppose we should bump the minor version number if we keep it.
* Bug fixes:
   * Interrupting `osg-gridadmin-cert-request` resulted in a NameError
   * When `KeyError` and `HTTPExceptions` were caught, `osg-gridadmin-cert-request` exited 0
   * Catch `SSLError` when using an expired cert

I ran the unit tests that I wrote a few months ago against all these changes and they all worked with the exception of the `CertRevokeTests` because of non-pki-tool related issue with OIM-ITB. 

I could break this up into different PRs but a lot of the changes (particularly the pylint ones) are all in the same areas. 