### PR TITLE
Fix handling of timeouts in OSG PKI tools

### DIFF
--- a/osgpkitools/ExceptionDefinitions.py
+++ b/osgpkitools/ExceptionDefinitions.py
@@ -15,18 +15,6 @@ class Exception_500response(Exception):
     def __str__(self):
         return str(self.message)
 
-class TimeoutException(Exception):
-    """ Exception raised for all timeouts
-
-    Attributes:
-        timeout -- timeout limit set after which the exception took place
-        """
-    def __init__(self,timeout):
-        self.timeout = timeout
-    
-    def __str__(self):
-        return "timeout: " + str(self.timeout)
-
 class FileNotFoundException(Exception):
     """ Exception raised when a file is not found
 

--- a/osgpkitools/osg-cert-request
+++ b/osgpkitools/osg-cert-request
@@ -93,7 +93,7 @@ def parse_args():
         default='',
         )
     parser.add_option(
-        '-t',
+        '-H',
         '--hostname',
         action='store',
         dest='hostname',
@@ -133,6 +133,14 @@ def parse_args():
         dest='phone',
         help='Phone number of user receiving certificate',
         metavar='PHONE',
+        )
+    parser.add_option(
+        '-t',
+        '--timeout',
+        action='store',
+        dest='timeout',
+        help='Specify the timeout in minutes',
+        default=5,
         )
     parser.add_option(
         '-T',
@@ -179,7 +187,7 @@ def parse_args():
     if not args.email:
         parser.error('-e/--email argument required')
     if not args.hostname and not args.csr:
-        parser.error('-t/--hostname or -c/--csr argument required')
+        parser.error('-H/--hostname or -c/--csr argument required')
     if args.hostname and args.csr:
         parser.error('Both -t/--hostname and -c/--csr arguments specified. Choose one')
 
@@ -218,6 +226,15 @@ def parse_args():
         raise FileNotFoundException(args.csr,
                                     'The file %s does not exist'
                                     % args.csr)
+
+    try:
+        timeout = int(args.timeout)
+        if not timeout >= 0:
+            charlimit_textwrap('Your timeout value cannot be a negative integer.\n')
+            raise ValueError
+    except ValueError:
+        raise ValueError('Invalid timeout value. Please enter a non-negative integer value.\n')
+
     if args.write_directory:
         if args.write_directory[-1] != '/':
             args.write_directory = args.write_directory + '/'
@@ -242,6 +259,8 @@ def parse_args():
         arguments.update({'comment': comment})
     if vars().has_key('pem_filename'):
         arguments.update({'pem_filename': pem_filename})
+    arguments.update({'timeout': timeout})
+    print 'The timeout is set to %s' % arguments['timeout']
     arguments.update({'email': email})
     arguments.update({'name': name})
     arguments.update({'phone': phone})
@@ -307,6 +326,7 @@ if __name__ == '__main__':
     try:
         os.umask(0177)
         arguments = parse_args()
+        OSGPKIUtils.start_timeout_clock(arguments['timeout']*60)
         # The two modes in which the script is run are
         # 1. The user doesn't provide a csr:
         # Here we generate a private key for the user and also a
@@ -369,12 +389,6 @@ if __name__ == '__main__':
     except Exception_500response, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
-        sys.exit(1)
-    except TimeoutException, e:
-        charlimit_textwrap('Timeout reached in %s minutes. This script will now exit.'
-                            % e.timeout)
-        charlimit_textwrap(' You can open goc ticket to track this issue by going to https://ticket.grid.iu.edu\n'
-                           )
         sys.exit(1)
     except FileNotFoundException, e:
         charlimit_textwrap(e.message + ':' + e.filename)

--- a/osgpkitools/osg-cert-retrieve
+++ b/osgpkitools/osg-cert-retrieve
@@ -235,6 +235,7 @@ if __name__ == '__main__':
     try:
         os.umask(0177)
         arguments = parse_args()
+        OSGPKIUtils.start_timeout_clock(arguments['timeout'])
         path = os.getcwd()
         check_permissions(path)
         capi = ConnectAPI.ConnectAPI()
@@ -273,12 +274,6 @@ if __name__ == '__main__':
     except Exception_500response, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
-        sys.exit(1)
-    except TimeoutException, e:
-        charlimit_textwrap('Timeout reached in %s minutes. This script will now exit.'
-                            % e.timeout)
-        charlimit_textwrap(' You can open goc ticket to track this issue by going to https://ticket.grid.iu.edu\n'
-                           )
         sys.exit(1)
     except FileWriteException, e:
         charlimit_textwrap(e.message)

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -182,7 +182,7 @@ or specify from a file using -f/--hostfile.''')
     try:
         timeout = int(args.timeout)
         if not timeout >= 0:
-            charlimit_textwrap('Your timeout value cannot be a negative integer.\nExiting now')
+            charlimit_textwrap('Your timeout value cannot be a negative integer.\n')
             raise ValueError
     except ValueError:
         raise ValueError('Invalid timeout value. Please enter a non-negative integer value.\n')
@@ -250,15 +250,8 @@ or specify from a file using -f/--hostfile.''')
         arguments.update({'values': values})
     if vars().has_key('hostname'):
         arguments.update({'hostname': hostname})
-    if vars().has_key('domain'):
-        arguments.update({'domain': domain})
-    if vars().has_key('outkeyfile'):
-        arguments.update({'outkeyfile': outkeyfile})
-    if vars().has_key('timeout'):
-        arguments.update({'timeout': timeout})
-        print 'The timeout is set to %s' % arguments['timeout']
-    if vars().has_key('num_requests'):
-        arguments.update({'num_requests': num_requests})
+    arguments.update({'timeout': timeout})
+    print 'The timeout is set to %s' % arguments['timeout']
     arguments.update({'alt_names': args.alt_names})
     arguments.update({'usercert': usercert})
     arguments.update({'userprivkey': userprivkey})
@@ -426,7 +419,7 @@ def check_quota_limit(request_count, arguments):
         check_response_500(response)
         data = response.read()
         conn.close()
-        iterations = check_for_pending(data, iterations, **arguments)
+        iterations = check_for_pending(iterations)
     check_failed_response(data)
     global_hostcert_year_max = \
         simplejson.loads(data)['global_hostcert_year_max']
@@ -566,9 +559,12 @@ if __name__ == '__main__':
     try:
         os.umask(0177)
         arguments = parse_args()
+        OSGPKIUtils.start_timeout_clock(arguments['timeout']*60)
         check_permissions(arguments['certdir'])
         ssl_context = get_ssl_context(**arguments)
         arguments.update({'ssl_context':ssl_context})
+
+        # Request cert(s)
         if not arguments.has_key('hostname'):
             process_hostfile_mode(**arguments)
         else:
@@ -593,10 +589,6 @@ if __name__ == '__main__':
     except Exception_500response, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
-        sys.exit(1)
-    except TimeoutException, e:
-        charlimit_textwrap('Timeout reached in %s minutes. This script will now exit.' % e.timeout)
-        charlimit_textwrap(' You can open goc ticket to track this issue by going to https://ticket.grid.iu.edu\n')
         sys.exit(1)
     except KeyError, e:
         print_exception_message(e)

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -186,7 +186,6 @@ or specify from a file using -f/--hostfile.''')
             raise ValueError
     except ValueError:
         raise ValueError('Invalid timeout value. Please enter a non-negative integer value.\n')
-    print 'Using timeout of %d minutes' % timeout
 
     if args.write_directory:
         certdir = args.write_directory

--- a/osgpkitools/osg-user-cert-renew
+++ b/osgpkitools/osg-user-cert-renew
@@ -289,7 +289,7 @@ def connect_retrieve(**arguments):
             raise httplib.HTTPException
         check_response_500(response)
         json = response.read()
-        iterations = check_for_pending(json, iterations, **arguments)
+        iterations = check_for_pending(iterations)
     conn.close()
     check_failed_response(json)
     data = simplejson.loads(json)
@@ -337,6 +337,7 @@ if __name__ == '__main__':
     try:
         os.umask(0177)
         arguments = parse_args()
+        OSGPKIUtils.start_timeout_clock(arguments['timeout'])
         arguments['ssl_context'] = get_ssl_context(**arguments)
         arguments = extract_info(**arguments)
         process_renew(**arguments)
@@ -359,11 +360,6 @@ if __name__ == '__main__':
     except Exception_500response, e:
         charlimit_textwrap('Request Failed. Status %s' % e.status)
         charlimit_textwrap('Reason for failure %s' % e.message)
-        sys.exit(1)
-    except TimeoutException, e:
-        charlimit_textwrap('Timeout reached in %s minutes. This script will now exit.' %
-                           e.timeout)
-        charlimit_textwrap(' You can open goc ticket to track this issue by going to https://ticket.grid.iu.edu\n')
         sys.exit(1)
     except FileNotFoundException, e:
         charlimit_textwrap(e.message + ':' + e.filename)


### PR DESCRIPTION
* Fix timeout option to respect tool runtime ([SOFTWARE-2258](https://jira.opensciencegrid.org/browse/SOFTWARE-2258))
* Added `-t/--timeout` to the tools that didn't have it. This caused a conflict in `osg-cert-request` with the `-t/--hostname` option so I changed that to `-H/--hostname` to match `osg-gridadmin-cert-request`. I could just as easily drop this change but common options across the tools really should be called the same way. I suppose we should bump the minor version number if we keep it.