### PR TITLE
Misc bug fixes

### DIFF
--- a/osgpkitools/OSGPKIUtils.py
+++ b/osgpkitools/OSGPKIUtils.py
@@ -182,7 +182,7 @@ def check_timeout(iterations, timeout):
 def charlimit_textwrap(string):
     """This function wraps up the output to 80 characters. Accepts string and print the wrapped output"""
 
-    list_string = textwrap.wrap(str(string))
+    list_string = textwrap.wrap(str(string), width=80)
     for line in list_string:
         print line
     return

--- a/osgpkitools/osg-cert-revoke
+++ b/osgpkitools/osg-cert-revoke
@@ -232,7 +232,7 @@ def connect_revoke(**arguments):
 
     charlimit_textwrap('Contacting Server to revoke the %s certificate \n' % revoke_text['cert_type'])
     
-    conn = M2Crypto.httpslib.HTTPSConnection(arguments['hostsec'],
+    conn = httpslib.HTTPSConnection(arguments['hostsec'],
                                              ssl_context=arguments['ssl_context'])
     try:
         conn.request('POST', arguments[url], params, headers)

--- a/osgpkitools/osg-cert-revoke
+++ b/osgpkitools/osg-cert-revoke
@@ -3,7 +3,7 @@
 import sys
 import urllib
 import httplib
-import M2Crypto
+from M2Crypto import httpslib, SSL
 import simplejson
 import traceback
 import os
@@ -241,8 +241,10 @@ def connect_revoke(**arguments):
         charlimit_textwrap('Connection to %s failed: %s'
                            % (arguments[url], repr(e)))
         raise e
-    except AttributeError, e:
-        raise e
+    except SSL.SSLError, exc:
+        charlimit_textwrap("="*80 + "ERROR: There was an issue with your credentials!")
+        charlimit_textwrap(exc.message)
+        sys.exit(1)
     check_response_500(response)
     if not 'OK' in response.reason:
         raise NotOKException(response.status, response.message)

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -602,9 +602,11 @@ if __name__ == '__main__':
     except KeyError, e:
         print_exception_message(e)
         charlimit_textwrap('Key %s not found' % e)
+        sys.exit(1)
     except httplib.HTTPException, e:
         print_exception_message(e)
         charlimit_textwrap('Connection failed: %s' % (e))
+        sys.exit(1)
     except FileWriteException, e:
         charlimit_textwrap(e.message)
         charlimit_textwrap("The script will exit now\n")

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -585,8 +585,8 @@ if __name__ == '__main__':
     except SSLError, e:
         print_exception_message(e)
         sys.exit('Please check for valid certificate.\n')
-    except KeyboardInterrupt, k:
-        print_exception_message(e)
+    except KeyboardInterrupt, exc:
+        print_exception_message(exc)
         sys.exit('''Interrupted by user\n''')
     except OSError, e:
         print_exception_message(e)

--- a/tests/pkiunittest.py
+++ b/tests/pkiunittest.py
@@ -82,8 +82,8 @@ def run_command(cmd, env=None):
 def run_python(script, *args):
     '''Run osg-pki-tools script '''
     script_path = os.path.join(SCRIPTS_PATH, script)
-    full_cmd = (sys.executable, script_path) + args
-    return run_command(full_cmd, env=os.environ)
+    py_cmd = (sys.executable, script_path) + args
+    return run_command(py_cmd, env=os.environ)
 
 class OIM(object):
     """OIM and cert/key pair interface"""
@@ -179,7 +179,7 @@ class OIM(object):
         if not self.reqid and '--help' not in opts:
             raise CertFileError('Could not revoke cert due to missing request ID\n')
         args = opts + ('--test', self.reqid, 'osg-pki-tools unit test - user revoke')
-        cmd = (os.path.join(SCRIPTS_PATH, 'osg-user-cert-revoke'),) + args
+        cmd = ('/bin/sh', os.path.join(SCRIPTS_PATH, 'osg-user-cert-revoke'),) + args
         return run_command(cmd)
 
     @staticmethod


### PR DESCRIPTION
* Interrupting `osg-gridadmin-cert-request` resulted in a NameError
* When `KeyError` and `HTTPExceptions` were caught, `osg-gridadmin-cert-request` exited 0
* Catch `SSLError` when using an expired cert