### PR TITLE
Fix bug that caused cert request timeouts to be in hrs rather than min

### DIFF
--- a/osgpkitools/osg-cert-request
+++ b/osgpkitools/osg-cert-request
@@ -326,7 +326,7 @@ if __name__ == '__main__':
     try:
         os.umask(0177)
         arguments = parse_args()
-        OSGPKIUtils.start_timeout_clock(arguments['timeout']*60)
+        OSGPKIUtils.start_timeout_clock(arguments['timeout'])
         # The two modes in which the script is run are
         # 1. The user doesn't provide a csr:
         # Here we generate a private key for the user and also a

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -559,7 +559,7 @@ if __name__ == '__main__':
     try:
         os.umask(0177)
         arguments = parse_args()
-        OSGPKIUtils.start_timeout_clock(arguments['timeout']*60)
+        OSGPKIUtils.start_timeout_clock(arguments['timeout'])
         check_permissions(arguments['certdir'])
         ssl_context = get_ssl_context(**arguments)
         arguments.update({'ssl_context':ssl_context})


### PR DESCRIPTION
After looking into M2Crypto possibly blocking signals, I noticed that my math was just wrong. 