### PR TITLE
Misc timeout-related improvements

### DIFF
--- a/osgpkitools/osg-cert-request
+++ b/osgpkitools/osg-cert-request
@@ -213,12 +213,8 @@ def parse_args():
         raise ValidationException("Phone number should contain \
                                   only numbers and/or '-'\n")
 
-    try:
-        timeout = int(args.timeout)
-        if not timeout >= 0:
-            charlimit_textwrap('Your timeout value cannot be a negative integer.\n')
-            raise ValueError
-    except ValueError:
+    timeout = int(args.timeout)
+    if not timeout >= 0:
         raise ValueError('Invalid timeout value. Please enter a non-negative integer value.\n')
 
     if args.write_directory:
@@ -246,7 +242,7 @@ def parse_args():
     if vars().has_key('pem_filename'):
         arguments.update({'pem_filename': pem_filename})
     arguments.update({'timeout': timeout})
-    print 'The timeout is set to %s' % arguments['timeout']
+    print 'Using timeout of %d minutes' % timeout
     arguments.update({'email': email})
     arguments.update({'name': name})
     arguments.update({'phone': phone})

--- a/osgpkitools/osg-cert-retrieve
+++ b/osgpkitools/osg-cert-retrieve
@@ -218,11 +218,11 @@ if __name__ == '__main__':
     try:
         os.umask(0177)
         arguments = parse_args()
-        OSGPKIUtils.start_timeout_clock(arguments['timeout'])
         path = os.getcwd()
         check_permissions(path)
         capi = ConnectAPI.ConnectAPI()
         print 'Connecting server to retrieve certificate...'
+        OSGPKIUtils.start_timeout_clock(arguments['timeout'])
         pkcs7raw = capi.retrieve_unauthenticated(**arguments)
         if os.path.exists(arguments['pem_filename']):
             pem_filename = arguments['pem_filename']

--- a/osgpkitools/osg-cert-retrieve
+++ b/osgpkitools/osg-cert-retrieve
@@ -128,14 +128,9 @@ def parse_args():
     if args.id:
         charlimit_textwrap("The '-i' flag is deprecated and no longer needed when specifying a request ID.")
 
-    try:
-        timeout = int(args.timeout)
-        if not timeout >= 0:
-            raise ValidationException('Your timeout value cannot be a negative integer.\nExiting now')
-    except ValueError:
-        charlimit_textwrap('Invalid timeout value. Please enter a non-negative integer.')
-        raise
-    print 'Using timeout of %d minutes' % timeout
+    timeout = int(args.timeout)
+    if not timeout >= 0:
+        raise ValueError('Invalid timeout value. Please enter a non-negative integer value.\n')
 
     pem_filename = args.certfile
 
@@ -165,9 +160,9 @@ def parse_args():
 
     if vars().has_key('pem_filename'):
         arguments.update({'pem_filename': pem_filename})
-    if vars().has_key('timeout'):
-        arguments.update({'timeout': timeout})
 
+    arguments.update({'timeout': timeout})
+    print 'Using timeout of %d minutes' % timeout
     arguments.update({'id': reqid})
     arguments.update({'filetype': filetype})
     arguments.update({'fileext': fileext})

--- a/osgpkitools/osg-cert-revoke
+++ b/osgpkitools/osg-cert-revoke
@@ -145,12 +145,8 @@ def parse_args():
     arguments = dict()
     arguments = CreateOIMConfig(args.test, **arguments)
 
-    try:
-        timeout = int(args.timeout)
-        if not timeout >= 0:
-            charlimit_textwrap('Your timeout value cannot be a negative integer.\n')
-            raise ValueError
-    except ValueError:
+    timeout = int(args.timeout)
+    if not timeout >= 0:
         raise ValueError('Invalid timeout value. Please enter a non-negative integer value.\n')
 
     if args.userprivkey is None:
@@ -193,7 +189,7 @@ def parse_args():
     arguments.update({'usercert': usercert})
     arguments.update({'userprivkey': userprivkey})
     arguments.update({'timeout': timeout})
-    print 'The timeout is set to %s' % arguments['timeout']
+    print 'Using timeout of %d minutes' % timeout
 
     return arguments
 
@@ -287,7 +283,7 @@ if __name__ == "__main__":
         charlimit_textwrap("Invalid passphrase entered, please try running the script again.")
         sys.exit(1)
     except (FileNotFoundException, BadCertificateException, HandshakeFailureException, KeyError,
-            httplib.HTTPException, AttributeError), exc:
+            httplib.HTTPException, AttributeError, ValueError), exc:
         print_exception_message(exc)
         sys.exit(1)
     except NotOKException, exc:

--- a/osgpkitools/osg-cert-revoke
+++ b/osgpkitools/osg-cert-revoke
@@ -9,6 +9,7 @@ import traceback
 import os
 from optparse import OptionParser
 
+from osgpkitools import OSGPKIUtils
 from osgpkitools.OSGPKIUtils import charlimit_textwrap
 from osgpkitools.OSGPKIUtils import CreateOIMConfig
 from osgpkitools.OSGPKIUtils import print_exception_message
@@ -68,6 +69,14 @@ def parse_args():
         dest='test',
         help='Run in test mode',
         default=False,
+        )
+    parser.add_option(
+        '-t',
+        '--timeout',
+        action='store',
+        dest='timeout',
+        help='Specify the timeout in minutes',
+        default=5,
         )
     parser.add_option(
         '-q',
@@ -136,6 +145,14 @@ def parse_args():
     arguments = dict()
     arguments = CreateOIMConfig(args.test, **arguments)
 
+    try:
+        timeout = int(args.timeout)
+        if not timeout >= 0:
+            charlimit_textwrap('Your timeout value cannot be a negative integer.\n')
+            raise ValueError
+    except ValueError:
+        raise ValueError('Invalid timeout value. Please enter a non-negative integer value.\n')
+
     if args.userprivkey is None:
         try:
             userprivkey = os.environ['X509_USER_KEY']
@@ -175,6 +192,8 @@ def parse_args():
     arguments.update({'user': args.user})
     arguments.update({'usercert': usercert})
     arguments.update({'userprivkey': userprivkey})
+    arguments.update({'timeout': timeout})
+    print 'The timeout is set to %s' % arguments['timeout']
 
     return arguments
 
@@ -261,6 +280,7 @@ if __name__ == "__main__":
         arguments = parse_args()
         ssl_context = get_ssl_context(**arguments)
         arguments.update({'ssl_context': ssl_context})
+        OSGPKIUtils.start_timeout_clock(arguments['timeout'])
         connect_revoke(**arguments)
 
     except BadPassphraseException, exc:

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -533,12 +533,12 @@ if __name__ == '__main__':
     try:
         os.umask(0177)
         arguments = parse_args()
-        OSGPKIUtils.start_timeout_clock(arguments['timeout'])
         check_permissions(arguments['certdir'])
         ssl_context = get_ssl_context(**arguments)
         arguments.update({'ssl_context':ssl_context})
 
         # Request cert(s)
+        OSGPKIUtils.start_timeout_clock(arguments['timeout'])
         if not arguments.has_key('hostname'):
             process_hostfile_mode(**arguments)
         else:

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -178,12 +178,8 @@ or specify from a file using -f/--hostfile.''')
     else:
         hostname = args.hostname
 
-    try:
-        timeout = int(args.timeout)
-        if not timeout >= 0:
-            charlimit_textwrap('Your timeout value cannot be a negative integer.\n')
-            raise ValueError
-    except ValueError:
+    timeout = int(args.timeout)
+    if not timeout >= 0:
         raise ValueError('Invalid timeout value. Please enter a non-negative integer value.\n')
 
     if args.write_directory:
@@ -250,7 +246,7 @@ or specify from a file using -f/--hostfile.''')
     if vars().has_key('hostname'):
         arguments.update({'hostname': hostname})
     arguments.update({'timeout': timeout})
-    print 'The timeout is set to %s' % arguments['timeout']
+    print 'Using timeout of %d minutes' % timeout
     arguments.update({'alt_names': args.alt_names})
     arguments.update({'usercert': usercert})
     arguments.update({'userprivkey': userprivkey})

--- a/osgpkitools/osg-user-cert-renew
+++ b/osgpkitools/osg-user-cert-renew
@@ -338,9 +338,9 @@ if __name__ == '__main__':
     try:
         os.umask(0177)
         arguments = parse_args()
-        OSGPKIUtils.start_timeout_clock(arguments['timeout'])
         arguments['ssl_context'] = get_ssl_context(**arguments)
         arguments = extract_info(**arguments)
+        OSGPKIUtils.start_timeout_clock(arguments['timeout'])
         process_renew(**arguments)
     except SystemExit:
         # We need to specifically catch sys.exit() so that it doesn't hit the catchall Exception below and

--- a/osgpkitools/osg-user-cert-renew
+++ b/osgpkitools/osg-user-cert-renew
@@ -104,13 +104,9 @@ def parse_args():
         version_info()
         sys.exit(1)
 
-    try:
-        timeout = int(args.timeout)
-        if not timeout > 0:
-            raise ValueError
-    except ValueError:
-        raise ValueError('Invalid timeout value. Please enter an integer value greater than zero.\n')
-    print 'Using timeout of %d minutes' % timeout
+    timeout = int(args.timeout)
+    if not timeout >= 0:
+        raise ValueError('Invalid timeout value. Please enter a non-negative integer value.\n')
 
     if args.userprivkey:
         userprivkey = args.userprivkey
@@ -152,6 +148,7 @@ def parse_args():
 
     arguments = CreateOIMConfig(args.test, **arguments)
     arguments.update({'timeout': timeout})
+    print 'Using timeout of %d minutes' % timeout
     arguments.update({'usercert': usercert})
     arguments.update({'userprivkey': userprivkey})
     arguments.update({'certdir': args.write_directory})


### PR DESCRIPTION
- Add timeout to osg-user-cert-revoke (SOFTWARE-2322)
- Address Mat's concerns in [SOFTWARE-2258](https://jira.opensciencegrid.org/browse/SOFTWARE-2258?focusedCommentId=336761&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-336761) about commands timing out during queries for user cert passwords
- Refactor goofy try/except blocks for timeout validation