### PR TITLE
Server-side quota verification (SOFTWARE-2472)

### DIFF
--- a/osgpkitools/ConnectAPI.py
+++ b/osgpkitools/ConnectAPI.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-import simplejson
+import json
 import urllib
 import httplib
 import M2Crypto
@@ -53,9 +53,9 @@ class ConnectAPI(object):
         check_failed_response(data)
         conn.close()
 
-        if simplejson.loads(data)['detail'] == 'Nothing to report' \
-            and simplejson.loads(data)['status'] == 'OK' in data:
-            request_id = simplejson.loads(data)['host_request_id']
+        if json.loads(data)['detail'] == 'Nothing to report' \
+            and json.loads(data)['status'] == 'OK' in data:
+            request_id = json.loads(data)['host_request_id']
         return request_id
 
     def request_authenticated(self, bulk_csr, **arguments):
@@ -88,7 +88,7 @@ class ConnectAPI(object):
             print_failure_reason_exit(data)
         conn.close()
         check_failed_response(data)
-        return_data = simplejson.loads(data)
+        return_data = json.loads(data)
         for (key, value) in return_data.iteritems():
             if 'host_request_id' in key:
                 reqid = value
@@ -122,7 +122,7 @@ class ConnectAPI(object):
         data = response.read()
         if not 'PENDING' in response.reason:
             if not 'OK' in response.reason:
-                raise NotOKException(simplejson.loads(data)['status'], simplejson.loads(data)['detail'].lstrip())
+                raise NotOKException(json.loads(data)['status'], json.loads(data)['detail'].lstrip())
 
         iterations = 0
         while 'PENDING' in data:
@@ -131,8 +131,8 @@ class ConnectAPI(object):
             iterations = check_for_pending(iterations)
 
         check_failed_response(data)
-        simplejson.dumps(simplejson.loads(data), sort_keys=True, indent=2)
-        return simplejson.loads(data)['pkcs7s']
+        json.dumps(json.loads(data), sort_keys=True, indent=2)
+        return json.loads(data)['pkcs7s']
 
     def retrieve_unauthenticated(self, **arguments):
         """This function checks if the request by an unauthenticated user
@@ -163,8 +163,8 @@ class ConnectAPI(object):
         response = self.do_connect(conn, 'POST', arguments['returl'], params, headers)
         data = response.read()
 
-        if simplejson.loads(data).has_key('request_status'):
-            if simplejson.loads(data)['request_status'] == 'REQUESTED':
+        if json.loads(data).has_key('request_status'):
+            if json.loads(data)['request_status'] == 'REQUESTED':
                 raise NotApprovedException('Certificate request is in Requested state. \
                 Needs to be Approved first. Please contact GA to approve this certificate\n')
             else:
@@ -183,7 +183,7 @@ class ConnectAPI(object):
             conn.close()
             iterations = check_for_pending(iterations)
         check_failed_response(data)
-        pkcs7raw = simplejson.loads(data)['pkcs7s'][0]
+        pkcs7raw = json.loads(data)['pkcs7s'][0]
         return pkcs7raw
 
     def issue(self, **arguments):
@@ -212,7 +212,7 @@ class ConnectAPI(object):
         data = response.read()
         conn.close()
         if not 'OK' in data:
-            raise NotOKException('Failed', simplejson.loads(data)['detail'])
+            raise NotOKException('Failed', json.loads(data)['detail'])
 
     def approve(self, **arguments):
 
@@ -251,7 +251,7 @@ class ConnectAPI(object):
             conn.close()
             check_failed_response(data)
         elif not 'OK' in data:
-            raise NotOKException('Failed', simplejson.loads(data)['detail'])
+            raise NotOKException('Failed', json.loads(data)['detail'])
 
     def renew(self, **arguments):
         """This function connects to the user renew API and passes the DN
@@ -279,7 +279,7 @@ class ConnectAPI(object):
             print_failure_reason_exit(data)
         conn.close()
         check_failed_response(data)
-        return_data = simplejson.loads(data)
+        return_data = json.loads(data)
         request_id = return_data['request_id']
         if not request_id:
             raise UnexpectedBehaviourException("Request Id not found in data. Script will now exit")

--- a/osgpkitools/ExceptionDefinitions.py
+++ b/osgpkitools/ExceptionDefinitions.py
@@ -112,19 +112,6 @@ class HandshakeFailureException(Exception):
     def __str__(self):
         return str(self.message)
 
-class QuotaException(Exception):
-    """This exception occurs when the approval quota of the user is predicted to be exceeded
-    in the current request.
-
-    Attributes:
-        message = message to be displayed"""
-
-    def __init__(self,message):
-        self.message = message
-    
-    def __str__(self):
-        return str(self.message)
-
 class ValidationException(Exception):
     """Exception occurs when validation fails
     Attributes:

--- a/osgpkitools/OSGPKIUtils.py
+++ b/osgpkitools/OSGPKIUtils.py
@@ -321,7 +321,7 @@ class Cert:
         self.pkey.assign_rsa(self.keypair)
 
 
-    def CreateX509Request(self, **config_items):
+    def CreateX509Request(self, commmon_name, alt_names=None, email=None):
         """This function accepts a dctionary that contains information regarding the CSR.
 ........It creates a CSR and returns it to the calling script."""
 
@@ -340,16 +340,16 @@ class Cert:
         x509name.add_entry_by_txt(  # common name
             field='CN',
             type=MBSTRING_ASC,
-            entry=config_items['CN'],
+            entry=commmon_name,
             len=-1,
             loc=-1,
             set=0,
             )
-        if config_items.has_key('emailAddress'):
+        if email:
             x509name.add_entry_by_txt(  # pkcs9 email address
                 field='emailAddress',
                 type=MBSTRING_ASC,
-                entry=config_items['emailAddress'],
+                entry=email,
                 len=-1,
                 loc=-1,
                 set=0,
@@ -357,7 +357,6 @@ class Cert:
 
         self.x509request.set_subject_name(x509name)
 
-        alt_names = config_items.get('alt_names')
         if alt_names:
             extension_stack = X509.X509_Extension_Stack()
             extension = X509.new_extension('subjectAltName',

--- a/osgpkitools/OSGPKIUtils.py
+++ b/osgpkitools/OSGPKIUtils.py
@@ -21,7 +21,7 @@ MBSTRING_ASC = MBSTRING_FLAG | 1
 MBSTRING_BMP = MBSTRING_FLAG | 2
 
 # The variable for storing version number for the scripts
-Version_Number = "1.2.20"
+VERSION_NUMBER = "1.2.21"
 
 
 def get_ssl_context(**arguments):

--- a/osgpkitools/OSGPKIUtils.py
+++ b/osgpkitools/OSGPKIUtils.py
@@ -7,7 +7,7 @@ import re
 import time
 import sys
 import textwrap
-import simplejson
+import json
 import signal
 import traceback
 import getpass
@@ -143,10 +143,10 @@ def print_failure_reason_exit(data):
     """This functions prints the failure reasons and exits"""
     try:
         msg = 'The request has failed for the following reason: %s' % \
-              simplejson.loads(data)['detail'].split('--')[1].lstrip()
+              json.loads(data)['detail'].split('--')[1].lstrip()
     except IndexError:
-        msg = 'The request has failed for the following reason: %s' % simplejson.loads(data)['detail'].lstrip() + \
-              'Status : %s ' % simplejson.loads(data)['status']
+        msg = 'The request has failed for the following reason: %s' % json.loads(data)['detail'].lstrip() + \
+              'Status : %s ' % json.loads(data)['status']
 
     # Print a helpful error message if OIM responds that the user needs to
     # provide a VO in their request. We cannot handle this in the arg parsing

--- a/osgpkitools/OSGPKIUtils.py
+++ b/osgpkitools/OSGPKIUtils.py
@@ -194,22 +194,7 @@ def format_csr(csr):
     """Extract the base64 encoded string from the contents of a CSR"""
     return csr.replace('-----BEGIN CERTIFICATE REQUEST-----\n', '')\
               .replace('-----END CERTIFICATE REQUEST-----\n', '')\
-              .replace('\n','')
-
-def get_request_count(filename):
-    '''Returns the number of hostname requested in the file supplied as -f during bulk certificate request'''
-
-    hostfile = open(filename, 'rb')
-    name_set = set()
-    count = 0
-    for line in hostfile.readlines():
-        line = line.strip(' \n')
-        if not line in name_set:
-            name_set.add(line)
-            count += 1
-    hostfile.close()
-    return count
-
+              .replace('\n', '')
 
 ### We take the whole certificate data as a string input
 ### Checking for /CN= in every line and extracting the term after that if not Digicert i.e. CA would be the hostname

--- a/osgpkitools/OSGPKIUtils.py
+++ b/osgpkitools/OSGPKIUtils.py
@@ -285,7 +285,6 @@ def CreateOIMConfig(isITB, **OIMConfig):
     OIMConfig.update({'userreturl': config.get(oim, 'userreturl')})
     OIMConfig.update({'userrevurl': config.get(oim, 'userrevurl')})
     OIMConfig.update({'issurl': config.get(oim, 'issurl')})
-    OIMConfig.update({'quotaurl': config.get(oim, 'quotaurl')})
     OIMConfig.update({'content_type': config.get(oim, 'content_type')})
     return OIMConfig
 

--- a/osgpkitools/osg-cert-request
+++ b/osgpkitools/osg-cert-request
@@ -323,15 +323,18 @@ if __name__ == '__main__':
             if cwd != None:
                 os.chdir(arguments['certdir'])
 
-            cert_obj = OSGPKIUtils.Cert()
-            cert_obj.CreatePKey(arguments['pem_filename'])
-            print 'Writing key to %s%s' %(arguments['certdir'], arguments['pem_filename'])
-            new_csr = cert_obj.CreateX509Request(arguments['hostname'], arguments['alt_names'], arguments['email'])
-            arguments['csr'] = OSGPKIUtils.format_csr(new_csr.as_pem())
+            keypath = os.path.join(arguments['certdir'], arguments['pem_filename'])
+            cert_obj = OSGPKIUtils.Cert(arguments['hostname'],
+                                        keypath,
+                                        arguments['alt_names'],
+                                        arguments['email'])
+            arguments['csr'] = cert_obj.base64_csr()
 
             if cwd != None:
                 os.chdir(cwd)
             connect(arguments)
+            print 'Writing key to %s' % keypath
+            cert_obj.write_pkey()
         else:
             csr = OSGPKIUtils.format_csr(open(arguments['csr'], 'rb').read())
             arguments.update({'csr': csr})

--- a/osgpkitools/osg-cert-request
+++ b/osgpkitools/osg-cert-request
@@ -96,7 +96,7 @@ def parse_args():
         dest='alt_names',
         help='Specify an alternative hostname for the CSR (FQDN). May be used more than once',
         metavar='HOSTNAME',
-        default=None
+        default=[]
         )
     parser.add_option(
         '-e',
@@ -317,10 +317,6 @@ if __name__ == '__main__':
         # lines of the csr and submit the request to the OIM
         cwd = None
         if arguments['csr'] is None:
-            config_items = {'CN': arguments['hostname'],
-                            'emailAddress': arguments['email'],
-                            'alt_names': arguments['alt_names']}
-
             if arguments['certdir'] != "./":
                 cwd = os.getcwd()
 
@@ -330,7 +326,7 @@ if __name__ == '__main__':
             cert_obj = OSGPKIUtils.Cert()
             cert_obj.CreatePKey(arguments['pem_filename'])
             print 'Writing key to %s%s' %(arguments['certdir'], arguments['pem_filename'])
-            new_csr = cert_obj.CreateX509Request(**config_items)
+            new_csr = cert_obj.CreateX509Request(arguments['hostname'], arguments['alt_names'], arguments['email'])
             arguments['csr'] = OSGPKIUtils.format_csr(new_csr.as_pem())
 
             if cwd != None:

--- a/osgpkitools/osg-cert-request
+++ b/osgpkitools/osg-cert-request
@@ -8,11 +8,11 @@ user.
 import urllib
 import httplib
 import sys
-import simplejson
 import os
 from optparse import OptionParser
 import subprocess
 from ssl import SSLError
+import simplejson
 
 from osgpkitools import OSGPKIUtils
 from osgpkitools import ConnectAPI

--- a/osgpkitools/osg-cert-request
+++ b/osgpkitools/osg-cert-request
@@ -12,7 +12,7 @@ import os
 from optparse import OptionParser
 import subprocess
 from ssl import SSLError
-import simplejson
+import json
 
 from osgpkitools import OSGPKIUtils
 from osgpkitools import ConnectAPI
@@ -292,9 +292,9 @@ def connect(arguments):
     data = response.read()
     check_failed_response(data)
     conn.close()
-    if simplejson.loads(data)['detail'] == 'Nothing to report' \
-        and simplejson.loads(data)['status'] == 'OK' in data:
-        ticket = simplejson.loads(data)['host_request_id']
+    if json.loads(data)['detail'] == 'Nothing to report' \
+        and json.loads(data)['status'] == 'OK' in data:
+        ticket = json.loads(data)['host_request_id']
         print 'Succesfully submitted'
         print 'Request Id#: %s' % ticket
     else:

--- a/osgpkitools/osg-cert-revoke
+++ b/osgpkitools/osg-cert-revoke
@@ -4,7 +4,7 @@ import sys
 import urllib
 import httplib
 from M2Crypto import httpslib, SSL
-import simplejson
+import json
 import traceback
 import os
 from optparse import OptionParser
@@ -263,12 +263,12 @@ def connect_revoke(**arguments):
     data = response.read()
     conn.close()
 
-    if simplejson.loads(data)['status'] == 'OK':
+    if json.loads(data)['status'] == 'OK':
         charlimit_textwrap("Successfully revoked %s certificate with %s ID: %s" %
                            (revoke_text['cert_type'], revoke_text['id_type'], str(arguments['id'])))
     else:
         charlimit_textwrap("Failure, could not revoke certificate.")
-        charlimit_textwrap(simplejson.loads(data)['detail'])
+        charlimit_textwrap(json.loads(data)['detail'])
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -430,7 +430,13 @@ if __name__ == '__main__':
 
         num_requests = len(hosts)
         if num_requests:
-            process_csr(num_requests, requests, **arguments)
+            try:
+                process_csr(num_requests, requests, **arguments)
+            except SystemExit, exc:
+                if 'You will exceed your host certificate quota' in exc:
+                    for key in keys:
+                        os.remove(key)
+                raise
 
     except SystemExit:
         # We need to specifically catch sys.exit() so that it doesn't hit the catchall Exception below and

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -363,7 +363,7 @@ def create_certificate_request(hostname, alt_names=None):
     return OSGPKIUtils.format_csr(request.as_pem()), keypath
 
 
-def process_csr(num_requests, bulk_csr, **arguments):
+def process_csr(bulk_csr, **arguments):
     """This function handles the entire processing of the request i.e.
     requesting. approving and then retrieving in sequence"""
     capi = ConnectAPI.ConnectAPI()
@@ -387,7 +387,7 @@ def process_csr(num_requests, bulk_csr, **arguments):
 
         print 'Issuing certificate...'
         pkcs7raw = capi.retrieve_authenticated(**arguments)
-        process_pkcs7(pkcs7raw, num_requests, **arguments)
+        process_pkcs7(pkcs7raw, len(bulk_csr), **arguments)
     except httplib.HTTPException, exc:
         charlimit_textwrap('Connection to %s failed: %s'% (arguments['newrequrl'], exc))
         raise
@@ -428,10 +428,9 @@ if __name__ == '__main__':
             keys.append(keypath)
             requests.append(csr)
 
-        num_requests = len(hosts)
-        if num_requests:
+        if len(requests):
             try:
-                process_csr(num_requests, requests, **arguments)
+                process_csr(requests, **arguments)
             except SystemExit, exc:
                 if 'You will exceed your host certificate quota' in exc:
                     for key in keys:

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -365,71 +365,9 @@ def create_certificate_request(hostname, reqid, config_items):
     return csr
 
 
-def check_quota_limit(request_count, arguments):
-    '''This function checks if the quota requirements for the user is met for the particular request'''
-
-    headers = {'Content-type': arguments['content_type'],
-               'User-Agent': 'OIMGridAPIClient/0.1 (OIM Grid API)'}
-    conn = httpslib.HTTPSConnection(arguments['host'], ssl_context=arguments['ssl_context'])
-    try:
-        conn.request('GET', arguments['quotaurl'], None, headers)
-        response = conn.getresponse()
-    except httplib.HTTPException, exc:
-        charlimit_textwrap('Connection to %s failed: %s'
-                           % (arguments['quotaurl'], exc))
-        raise
-    except Exception, exc:
-        if "sslv3 alert bad certificate" in exc:
-            raise BadCertificateException("Error connecting to server: %s.\n" + \
-                                          "Your certificate is not trusted by the server" % exc)
-        else:
-            print exc.__class__.__name__
-            raise
-    check_response_500(response)
-    data = response.read()
-    if not 'PENDING' in response.reason:
-        if not 'OK' in response.reason:
-            print_failure_reason_exit(data)
-    charlimit_textwrap('Waiting for response from Quota Check API. Please wait.')
-    iterations = 0
-    while 'PENDING' in data:
-        conn.request('GET', arguments['quotaurl'], headers)
-        try:
-            response = conn.getresponse()
-        except httplib.HTTPException, exc:
-            charlimit_textwrap('Connection to %s failed: %s'
-                               % (arguments['quotaurl'], exc))
-            raise
-        check_response_500(response)
-        data = response.read()
-        conn.close()
-        iterations = check_for_pending(iterations)
-    check_failed_response(data)
-    global_hostcert_year_max = \
-        simplejson.loads(data)['global_hostcert_year_max']
-    global_hostcert_year_count = \
-        simplejson.loads(data)['global_hostcert_year_count']
-    count_hostcert_day = simplejson.loads(data)['count_hostcert_day']
-    quota_hostcert_day_max = \
-        simplejson.loads(data)['quota_hostcert_day_max']
-    count_hostcert_year = simplejson.loads(data)['count_hostcert_year']
-    quota_hostcert_year_max = \
-        simplejson.loads(data)['quota_hostcert_year_max']
-    if global_hostcert_year_max >= global_hostcert_year_count \
-        + request_count and count_hostcert_day + request_count \
-        <= quota_hostcert_day_max and count_hostcert_year \
-        + request_count <= quota_hostcert_year_max \
-        and quota_hostcert_day_max >= request_count:
-        status = True
-    else:
-        status = False
-    conn.close()
-    return status
-
-
 def process_csr(num_requests, bulk_csr, **arguments):
     """This function handles the entire processing of the request i.e.
-    requesting. checking for quota limit, approving and then retrieving in sequence"""
+    requesting. approving and then retrieving in sequence"""
     capi = ConnectAPI.ConnectAPI()
 
     try:
@@ -469,10 +407,6 @@ def process_single_host_mode(**arguments):
     num_requests = 1
     config_items = {}
 
-    if check_quota_limit(num_requests, arguments):
-        pass
-    else:
-        raise QuotaException('Your request would exceed your quota. Aborting')
     hostname = arguments['hostname'].strip()
     config_items.update({'CN': hostname, 'alt_names': arguments['alt_names']})
     charlimit_textwrap('Beginning request process for %s' % hostname)
@@ -497,10 +431,6 @@ def process_hostfile_mode(**arguments):
     hosts = hosts_file.readlines()
     hosts_file.close()
 
-    if check_quota_limit(request_count, arguments):
-        pass
-    else:
-        raise QuotaException('Your request would exceed your quota. Aborting')
     for line in hosts:
         line = line.strip()
         if line != '' and line not in host_set:
@@ -514,8 +444,6 @@ def process_hostfile_mode(**arguments):
             # Remove / from service requests for proper FQDN formatting
             csr = create_certificate_request(hostname.replace('/', '-'), num_requests, config_items)
             bulk_csr.append(csr)
-            if num_requests == 50: # OIM limits bulk requests to 50 CSRs
-                break
     if num_requests > 0:
         process_csr(request_count, bulk_csr, **arguments)
 
@@ -574,7 +502,7 @@ if __name__ == '__main__':
         charlimit_textwrap(exc.message)
         sys.stderr.write("Usage: osg-gridadmin-cert-request -h for help \n")
         sys.exit(2) # Fix for returning exit code of 2 as in all the other scripts.
-    except (BadCertificateException, BadPassphraseException, HandshakeFailureException, QuotaException), exc:
+    except (BadCertificateException, BadPassphraseException, HandshakeFailureException), exc:
         charlimit_textwrap(exc.message)
         sys.exit(1)
     except (AttributeError, OSError, ValueError, EOFError, SSL.SSLError, UnexpectedBehaviourException), exc:

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -87,7 +87,7 @@ or specify from a file using -f/--hostfile.''')
         help='Specify an alternative hostname for CSR (FQDN). May be used more than ' + \
         'once and if specified, -f/--hostfile will be ignored',
         metavar='HOSTNAME',
-        default=None
+        default=[]
         )
     group.add_option(
         '-f',
@@ -345,8 +345,8 @@ def process_pkcs7(pkcs7, num_requests, **arguments):
     return
 
 
-def create_certificate_request(hostname, reqid, config_items):
-    """This function accepts hostname, request id and a dictionary of config_items for the CSR.
+def create_certificate_request(hostname, alt_names=None):
+    """This function accepts hostname and an optional list of SANs for the CSR.
     It writes the key and creates the CSR."""
 
     print 'Generating certificate...'
@@ -359,9 +359,8 @@ def create_certificate_request(hostname, reqid, config_items):
     cert_obj = OSGPKIUtils.Cert()
     cert_obj.CreatePKey(keypath)
     charlimit_textwrap('Writing key to %s' % keypath)
-    new_csr = cert_obj.CreateX509Request(**config_items)
-    csr = OSGPKIUtils.format_csr(new_csr.as_pem())
-    return csr
+    request = cert_obj.CreateX509Request(hostname, alt_names)
+    return OSGPKIUtils.format_csr(request.as_pem()), keypath
 
 
 def process_csr(num_requests, bulk_csr, **arguments):
@@ -399,53 +398,6 @@ def process_csr(num_requests, bulk_csr, **arguments):
         else:
             raise
 
-def process_single_host_mode(**arguments):
-    '''Create and process a single CSR with the --hostname option treated as
-    the CN and the --altname's treated as the alternative names'''
-
-    num_requests = 1
-    config_items = {}
-
-    hostname = arguments['hostname'].strip()
-    config_items.update({'CN': hostname, 'alt_names': arguments['alt_names']})
-    charlimit_textwrap('Beginning request process for %s' % hostname)
-    # Remove / from service requests for proper FQDN formatting
-    csr = create_certificate_request(hostname.replace('/', '-'), num_requests, config_items)
-    process_csr(num_requests, csr, **arguments)
-    return
-
-
-def process_hostfile_mode(**arguments):
-    '''Create and process CSRs for each line in the user-specified hostfile.
-    Each line may contain multiple hostnames (space delimited), the first one
-    is considered the CN and the rest are considered alternative names'''
-
-    bulk_csr = list()
-    num_requests = 0
-    host_set = set()
-    config_items = {}
-    request_count = get_request_count(arguments['hostfile'])
-
-    hosts_file = open(arguments['hostfile'], 'rb')
-    hosts = hosts_file.readlines()
-    hosts_file.close()
-
-    for line in hosts:
-        line = line.strip()
-        if line != '' and line not in host_set:
-            host_set.add(line)
-            num_requests += 1
-            # Take the first hostname as the CN and the rest as SANs
-            sans = line.split()
-            hostname = sans.pop(0)
-            config_items.update({'CN': hostname, 'alt_names': sans})
-            charlimit_textwrap('Beginning request process for %s' % line)
-            # Remove / from service requests for proper FQDN formatting
-            csr = create_certificate_request(hostname.replace('/', '-'), num_requests, config_items)
-            bulk_csr.append(csr)
-    if num_requests > 0:
-        process_csr(request_count, bulk_csr, **arguments)
-
 if __name__ == '__main__':
     try:
         os.umask(0177)
@@ -454,12 +406,32 @@ if __name__ == '__main__':
         ssl_context = get_ssl_context(**arguments)
         arguments.update({'ssl_context':ssl_context})
 
-        # Request cert(s)
         OSGPKIUtils.start_timeout_clock(arguments['timeout'])
-        if not arguments.has_key('hostname'):
-            process_hostfile_mode(**arguments)
+
+        if 'hostname' in arguments:
+            hosts = [tuple(arguments['hostname'].strip() + arguments['alt_names'])]
         else:
-            process_single_host_mode(**arguments)
+            with open(arguments['hostfile'], 'rb') as hosts_file:
+                host_lines = hosts_file.readlines()
+            hosts = [tuple(line.split()) for line in host_lines if line.strip()]
+
+        # Construct host list, skipping duplicates and empty lines
+        # NOTE: the same host with different SANs are not considered duplicates
+        keys = list()
+        requests = list()
+        for host in set(hosts):
+            cn = host[0]
+            sans = host[1:]
+            charlimit_textwrap('Beginning request process for %s' % cn)
+            # Remove / from service requests for proper FQDN formatting
+            csr, keypath = create_certificate_request(cn.replace('/', '-'), sans)
+            keys.append(keypath)
+            requests.append(csr)
+
+        num_requests = len(hosts)
+        if num_requests:
+            process_csr(num_requests, requests, **arguments)
+
     except SystemExit:
         # We need to specifically catch sys.exit() so that it doesn't hit the catchall Exception below and
         # print a confusing message for the user (SOFTWARE-1584)

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -25,7 +25,6 @@ from osgpkitools import OSGPKIUtils
 from osgpkitools.OSGPKIUtils import CreateOIMConfig
 from osgpkitools.OSGPKIUtils import extractHostname
 from osgpkitools.OSGPKIUtils import extractEEC
-from osgpkitools.OSGPKIUtils import get_request_count
 from osgpkitools.OSGPKIUtils import version_info
 from osgpkitools.OSGPKIUtils import check_permissions
 from osgpkitools.OSGPKIUtils import charlimit_textwrap

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -12,6 +12,7 @@ This script works in two modes:
 """
 
 import httplib
+import re
 import sys
 import os
 import subprocess
@@ -345,24 +346,6 @@ def process_pkcs7(pkcs7, num_requests, **arguments):
     return
 
 
-def create_certificate_request(hostname, alt_names=None):
-    """This function accepts hostname and an optional list of SANs for the CSR.
-    It writes the key and creates the CSR."""
-
-    print 'Generating certificate...'
-    keypath = os.path.join(arguments['certdir'], hostname + '-key.pem')
-    # Handle already existing key file...
-    if os.path.exists(keypath):
-        old_keypath = os.path.join(arguments['certdir'], hostname + "-key-old.pem")
-        print "Renaming existing key from %s to %s" % (keypath, old_keypath)
-        os.rename(keypath, old_keypath)
-    cert_obj = OSGPKIUtils.Cert()
-    cert_obj.CreatePKey(keypath)
-    charlimit_textwrap('Writing key to %s' % keypath)
-    request = cert_obj.CreateX509Request(hostname, alt_names)
-    return OSGPKIUtils.format_csr(request.as_pem()), keypath
-
-
 def process_csr(bulk_csr, **arguments):
     """This function handles the entire processing of the request i.e.
     requesting. approving and then retrieving in sequence"""
@@ -391,7 +374,7 @@ def process_csr(bulk_csr, **arguments):
     except httplib.HTTPException, exc:
         charlimit_textwrap('Connection to %s failed: %s'% (arguments['newrequrl'], exc))
         raise
-    except Exception, exc:
+    except SystemExit, exc:
         if 'sslv3 alert bad certificate' in exc:
             raise BadCertificateException("Error connecting to server: %s.\n" + \
                                           "Your certificate is not trusted by the server" % exc)
@@ -417,23 +400,35 @@ if __name__ == '__main__':
 
         # Construct host list, skipping duplicates and empty lines
         # NOTE: the same host with different SANs are not considered duplicates
-        keys = list()
         requests = list()
+        certs = list()
+        charlimit_textwrap('Beginning request process...')
         for host in set(hosts):
             cn = host[0]
             sans = host[1:]
-            charlimit_textwrap('Beginning request process for %s' % cn)
             # Remove / from service requests for proper FQDN formatting
-            csr, keypath = create_certificate_request(cn.replace('/', '-'), sans)
-            keys.append(keypath)
-            requests.append(csr)
+            cert_obj = OSGPKIUtils.Cert(cn.replace('/', '-'),
+                                        keypath=os.path.join(arguments['certdir'], cn + '-key.pem'),
+                                        altnames=sans)
+            certs.append(cert_obj)
 
-        if len(requests):
+        # We choose to write the keys before the request in case there are issues with the certs and only then perform
+        # cleanup if there's a quota failure; it's better to have keys and no certs than it is to have certs and no keys
+        if len(certs):
+            charlimit_textwrap("Writing key(s) to %s" % arguments['certdir'])
+            for cert in certs:
+                # Handle already existing key file...
+                if os.path.exists(cert.keypath):
+                    old_keypath = re.sub(r'\.pem$', '-old.pem', cert.keypath)
+                    print "Renaming existing key from %s to %s" % (cert.keypath, old_keypath)
+                    os.rename(cert.keypath, old_keypath)
+                cert.write_pkey()
             try:
-                process_csr(requests, **arguments)
+                process_csr([cert.base64_csr() for cert in certs], **arguments)
             except SystemExit, exc:
-                if 'You will exceed your host certificate quota' in exc:
-                    for key in keys:
+                if 'certificate quota' in str(exc):
+                    print "Cleaning up key(s) in %s" % arguments['certdir']
+                    for key in [cert.keypath for cert in certs]:
                         os.remove(key)
                 raise
 

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -13,27 +13,23 @@ This script works in two modes:
 
 import httplib
 import sys
-import simplejson
 import os
-from M2Crypto import SSL, httpslib
-from optparse import OptionParser, OptionGroup
 import subprocess
-from ssl import SSLError
 import tempfile
+
+from ssl import SSLError
+from optparse import OptionParser, OptionGroup
+from M2Crypto import SSL
 
 from osgpkitools import OSGPKIUtils
 from osgpkitools.OSGPKIUtils import CreateOIMConfig
 from osgpkitools.OSGPKIUtils import extractHostname
 from osgpkitools.OSGPKIUtils import extractEEC
 from osgpkitools.OSGPKIUtils import get_request_count
-from osgpkitools.OSGPKIUtils import check_response_500
-from osgpkitools.OSGPKIUtils import check_failed_response
-from osgpkitools.OSGPKIUtils import check_for_pending
 from osgpkitools.OSGPKIUtils import version_info
 from osgpkitools.OSGPKIUtils import check_permissions
 from osgpkitools.OSGPKIUtils import charlimit_textwrap
 from osgpkitools.OSGPKIUtils import print_exception_message
-from osgpkitools.OSGPKIUtils import print_failure_reason_exit
 from osgpkitools.OSGPKIUtils import print_uncaught_exception
 from osgpkitools.OSGPKIUtils import get_ssl_context
 from osgpkitools.ExceptionDefinitions import *

--- a/osgpkitools/osg-user-cert-renew
+++ b/osgpkitools/osg-user-cert-renew
@@ -365,7 +365,7 @@ if __name__ == '__main__':
         print_exception_message(exc)
         sys.exit(1)
     except (FileWriteException, BadCertificateException, BadPassphraseException, HandshakeFailureException,
-            QuotaException, UnexpectedBehaviourException, InsufficientArgumentException), exc:
+            UnexpectedBehaviourException, InsufficientArgumentException), exc:
         charlimit_textwrap(exc.message)
         sys.exit(1)
     except Exception, exc:

--- a/osgpkitools/osg-user-cert-renew
+++ b/osgpkitools/osg-user-cert-renew
@@ -4,7 +4,7 @@
 import urllib
 import httplib
 import sys
-import simplejson
+import json
 import re
 import os
 import errno
@@ -212,7 +212,7 @@ def connect_renew(**arguments):
         print_failure_reason_exit(data)
     conn.close()
     check_failed_response(data)
-    return_data = simplejson.loads(data)
+    return_data = json.loads(data)
     request_id = return_data['request_id']
     if not request_id:
         raise UnexpectedBehaviourException("Request Id not found in data. Script will now exit")
@@ -290,7 +290,7 @@ def connect_retrieve(**arguments):
         iterations = check_for_pending(iterations)
     conn.close()
     check_failed_response(json)
-    data = simplejson.loads(json)
+    data = json.loads(json)
     pkcs12 = base64.b64decode(data['pkcs12'])
 
     write_certificate(pkcs12, arguments)

--- a/osgpkitools/pki-clients.ini
+++ b/osgpkitools/pki-clients.ini
@@ -9,7 +9,6 @@ canurl: /oim/rest?action=host_certs_cancel&version=1
 returl: /oim/rest?action=host_certs_retrieve&version=1
 issurl: /oim/rest?action=host_certs_issue&version=1
 content_type: application/x-www-form-urlencoded
-quotaurl: /oim/rest?action=user_info
 renewurl: /oim/rest?action=user_cert_renew&version=1
 userreturl: /oim/rest?action=user_cert_retrieve&version=1
 userrevurl: /oim/rest?action=user_cert_revoke&version=1
@@ -25,7 +24,6 @@ canurl: /oim/rest?action=host_certs_cancel&version=1
 returl: /oim/rest?action=host_certs_retrieve&version=1
 issurl: /oim/rest?action=host_certs_issue&version=1
 content_type: application/x-www-form-urlencoded
-quotaurl: /oim/rest?action=user_info
 renewurl: /oim/rest?action=user_cert_renew&version=1
 userreturl: /oim/rest?action=user_cert_retrieve&version=1
 userrevurl: /oim/rest?action=user_cert_revoke&version=1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name = "OSGPKITools",
-    version = "1.2.20",
+    version = "1.2.21",
     author = "Rohan Mathure",
     author_email = "rmathure@indiana.edu",
     maintainer = "Brian Lin",

--- a/tests/BasicTests.py
+++ b/tests/BasicTests.py
@@ -33,12 +33,8 @@ class BasicTests(PKIClientTestCase.PKIClientTestCase):
 			 self._get_key_modulus())
 
     def test_json(self):
-	"""Test we can import json or simplejson"""
-	try:
-	    import json
-	except ImportError:
-	    import simplejson as json
-
+	"""Test we can import json"""
+	import json
     #
     # Utility methods
     #

--- a/tests/OSGPKIUtilsTests.py
+++ b/tests/OSGPKIUtilsTests.py
@@ -14,31 +14,20 @@ from osgpkitools import OSGPKIUtils
 
 class OSGPKIUtilsTests(unittest.TestCase):
     FQDN = 'test.' + DOMAIN
-    
-    def __generate_csr(self, config):
-        '''Helper for CSR generation'''
-        test_cert = OSGPKIUtils.Cert()
-        key_file = self.FQDN + '-key.pem'
-        test_cert.CreatePKey(key_file)
-        csr = test_cert.CreateX509Request(**config)
-        self.assert_(csr, 'Could not create CSR')
-        return csr
-        
+    KEYPATH = FQDN + '-key.pem'
+
     def test_csr_generation(self):
         '''Generate a basic CSR'''
-        config = {'CN': self.FQDN,
-                  'emailAddress': EMAIL,
-                  'alt_names': []}
-        self.__generate_csr(config)
-        
+        cert = OSGPKIUtils.Cert(self.FQDN, self.KEYPATH, email=EMAIL)
+        self.assert_(cert.x509request, 'missing CSR contents')
+
     def test_alt_name_csr_generation(self):
         '''Generate a CSR with multiple SANs'''
         alias = 'test-san.' + DOMAIN
-        config = {'CN': self.FQDN,
-                  'emailAddress': EMAIL,
-                  'alt_names': [alias]}
-        csr_contents = self.__generate_csr(config).as_text()
-        self.assert_(re.search(r'X509v3 Subject Alternative Name: critical', csr_contents), 
+        cert = OSGPKIUtils.Cert(self.FQDN, self.KEYPATH, altnames=[alias], email=EMAIL)
+        csr_contents = cert.x509request.as_text()
+        print csr_contents
+        self.assert_(re.search(r'X509v3 Subject Alternative Name: critical', csr_contents),
                      "Subject Alternative Name not marked as 'critical'\n" + csr_contents)
         found_names = set(match.group(1) for match in re.finditer(r'DNS:([\w\-\.]+)', csr_contents))
         expected_names = set([alias])

--- a/tests/OSGPKIUtilsTests.py
+++ b/tests/OSGPKIUtilsTests.py
@@ -2,7 +2,7 @@
 
 import re
 import signal
-from simplejson import dumps
+from json import dumps
 import sys
 import unittest
 

--- a/tests/README.RELEASE_TESTING
+++ b/tests/README.RELEASE_TESTING
@@ -120,11 +120,9 @@ One the VM:
 
 3) sudo pip-python install scripttests unittest2  # Needed for testing
 
-4) sudo yum install --enablerepo=osg-development python-simplejson
+4) sudo yum install openssl-devel gcc python-devel  # Needed for pyton ssl
 
-5) sudo yum install openssl-devel gcc python-devel  # Needed for pyton ssl
-
-6) sudo pip-python install ssl
+5) sudo pip-python install ssl
 
 Now test as above.
 

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -15,7 +15,7 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OS_VERSION}
 echo "exclude=mirror.beyondhosting.net" >> /etc/yum/pluginconf.d/fastestmirror.conf
 
 yum -y install yum-plugin-priorities
-yum -y install m2crypto python-simplejson
+yum -y install m2crypto
 
 # Run unit tests
 pushd osg-pki-tools/tests/


### PR DESCRIPTION
Take 2, cleaning up the keys if we make requests over quota. Also various other cleanups so that the tools aren't a nightmare to work with.

I've tested this and verified that I can request certs when I'm under quota and when I'm over quota the command fails and there are no keys left on disk.