### PR TITLE
Move old keys iff OIM successful (SOFTWARE-3000)

### DIFF
--- a/osgpkitools/osg-cert-request
+++ b/osgpkitools/osg-cert-request
@@ -117,16 +117,23 @@ def unauthenticated_request(config, name, email, phone, hostname=None, altnames=
     if (not hostname and not csr_path) or (hostname and csr_path):
         raise TypeError("unauthenticated_request() requires only one of hostname or csr_path arguments to be defined")
 
+    capi = ConnectAPI.ConnectAPI()
+
     if csr_path is None:
         common_name = hostname.replace('/', '-')
         cert = OSGPKIUtils.Cert(common_name,
                                 keypath=os.path.join(write_directory, common_name + '-key.pem'),
                                 altnames=altnames,
                                 email=email)
-        print "Writing key to %s" % cert.keypath
-        cert.write_pkey()
-
         csr = cert.base64_csr()
+        try:
+            capi.request_unauthenticated(config, name, email, phone, csr, vo, cc, comment)
+        except:
+            os.remove(cert.newkey)
+            raise
+        else:
+            print "Writing key to %s" % cert.keypath
+            cert.write_pkey()
     else:
         OSGPKIUtils.charlimit_textwrap('CSR input found. Skipping creation of the primary key')
         try:
@@ -134,9 +141,8 @@ def unauthenticated_request(config, name, email, phone, hostname=None, altnames=
         except OSError, exc:
             OSGPKIUtils.charlimit_textwrap('Failed to read CSR file: %s' % exc)
             sys.exit(1)
+        capi.request_unauthenticated(config, name, email, phone, csr, vo, cc, comment)
 
-    capi = ConnectAPI.ConnectAPI()
-    capi.request_unauthenticated(config, name, email, phone, csr, vo, cc, comment)
     OSGPKIUtils.charlimit_textwrap('Request Id#: %s' % capi.reqid)
 
 def main():
@@ -169,19 +175,24 @@ def main():
         else:
             cert = OSGPKIUtils.Cert(args.hostname, os.path.join(args.write_directory, args.keyfile),
                                     altnames=args.alt_names, email=args.email)
-            print "Writing key to %s" % cert.keypath
-            cert.write_pkey()
 
-            oim = ConnectAPI.ConnectAPI()
-            print 'Requesting certificate...'
-            oim.request_authenticated(config, [cert.base64_csr()], ssl_ctx, args.vo, args.cc_list)
-            print 'OIM Request ID: %s' % oim.reqid
+            try:
+                oim = ConnectAPI.ConnectAPI()
+                print 'Requesting certificate...'
+                oim.request_authenticated(config, [cert.base64_csr()], ssl_ctx, args.vo, args.cc_list)
+                print 'OIM Request ID: %s' % oim.reqid
 
-            print 'Connecting to server to approve certificate...'
-            oim.approve(config, ssl_ctx)
+                print 'Connecting to server to approve certificate...'
+                oim.approve(config, ssl_ctx)
 
-            print 'Retrieving certificate...'
-            hostname, cert_string = oim.retrieve(config)[0]
+                print 'Retrieving certificate...'
+                hostname, cert_string = oim.retrieve(config)[0]
+            except:
+                os.remove(cert.newkey)
+                raise
+            else:
+                print "Writing key to %s" % cert.keypath
+                cert.write_pkey()
 
             cert_path = os.path.join(args.write_directory, hostname + '.pem')
             OSGPKIUtils.safe_rename(cert_path)

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -12,11 +12,8 @@ This script works in two modes:
 """
 
 import httplib
-import re
 import sys
 import os
-import subprocess
-import tempfile
 
 from ssl import SSLError
 from optparse import OptionParser, OptionGroup
@@ -24,8 +21,6 @@ from M2Crypto import SSL
 
 from osgpkitools import OSGPKIUtils
 from osgpkitools.OSGPKIUtils import read_config
-from osgpkitools.OSGPKIUtils import extractHostname
-from osgpkitools.OSGPKIUtils import extractEEC
 from osgpkitools.OSGPKIUtils import version_info
 from osgpkitools.OSGPKIUtils import check_permissions
 from osgpkitools.OSGPKIUtils import charlimit_textwrap

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -276,20 +276,19 @@ if __name__ == '__main__':
             certs.append(cert_obj)
 
         # We choose to write the keys before the request in case there are issues with the certs and only then perform
-        # cleanup if there's a quota failure; it's better to have keys and no certs than it is to have certs and no keys
+        # cleanup if there's a failure; it's better to have keys and no certs than it is to have certs and no keys
         if len(certs):
-            charlimit_textwrap("Writing key(s) to %s" % ARGS['certdir'])
-            for cert in certs:
-                cert.write_pkey()
             try:
                 process_csr(CONFIG, [cert.base64_csr() for cert in certs], ssl_context,
                             ARGS['vo'], ARGS['cc_list'], ARGS['certdir'])
-            except SystemExit, exc:
-                if 'certificate quota' in str(exc):
-                    print "Cleaning up key(s) in %s" % ARGS['certdir']
-                    for key in [cert.keypath for cert in certs]:
-                        os.remove(key)
+            except:
+                for cert in certs:
+                    os.remove(cert.newkey)
                 raise
+            else:
+                charlimit_textwrap("Writing key(s) to %s" % ARGS['certdir'])
+                for cert in certs:
+                    cert.write_pkey()
 
     except SystemExit:
         # We need to specifically catch sys.exit() so that it doesn't hit the catchall Exception below and

--- a/tests/GridadminCertRequestTests.py
+++ b/tests/GridadminCertRequestTests.py
@@ -80,7 +80,7 @@ class GridadminCertRequestTests(unittest.TestCase):
         try:
             # TODO: instead of parsing output, we should assert existence of the old cert/key paths
             old_cert_path = re.search(r'Renamed existing file from.*to (.*)', stdout).group(1)
-            old_key_path = re.search(r'Renamed existing file from.*to (.*-key.pem)', stdout).group(1)
+            old_key_path = re.search(r'Renamed existing file from.*to (.*-key.pem.old)', stdout).group(1)
         except AttributeError:
             self.fail('Failed to move old cert or key\n' + msg)
 

--- a/tests/pkiunittest.py
+++ b/tests/pkiunittest.py
@@ -104,9 +104,14 @@ class OIM(object):
                                              '--directory', TEST_PATH,
                                              '--vo', TEST_VO,
                                              *opts)
-        attr_regex = r'Writing key to ([^\n]+).*OIM Request ID: (\d+)'
+
         try:
-            key_path, self.reqid = re.search(attr_regex, stdout, re.MULTILINE|re.DOTALL).groups()
+            self.reqid = re.search(r'OIM Request ID: (\d+)', stdout).group(1)
+        except AttributeError:
+            msg = 'Could not parse stdout for key or request ID\n' + msg
+
+        try:
+            key_path = re.search(r'Writing key to ([^\n]+)', stdout).group(1)
         except AttributeError:
             msg = 'Could not parse stdout for key or request ID\n' + msg
         else:


### PR DESCRIPTION
Instead of moving the old keys out of the way and moving them back upon failure. I opted to do temp files per key rather than an entire folder for all the keys because the latter would be annoying to implement with multiple instances without any benefit from what I could discern.

EDIT: Oh the `CertRequestTests.py`, `GridAdminCertRequestTests.py`, and `OSGPKIUtils.py` tests pass