### PR TITLE
Fix config file read order

### DIFF
--- a/osgpkitools/OSGPKIUtils.py
+++ b/osgpkitools/OSGPKIUtils.py
@@ -333,9 +333,9 @@ def read_config(itb, config_files=None):
     config = ConfigParser.ConfigParser()
     # I don't expect user-specified config files to be used except for testing
     if not config_files:
-        config_files = [os.path.expanduser('~/.osg-pki/OSG_PKI.ini'),
+        config_files = ['/etc/osg/pki-clients.ini',
                         'pki-clients.ini',
-                        '/etc/osg/pki-clients.ini'] # config(noreplace) in packaging
+                        os.path.expanduser('~/.osg-pki/OSG_PKI.ini')]
 
     if not config.read(config_files):
         config.readfp(StringIO(DEFAULT_CONFIG))

--- a/tests/pkiunittest.py
+++ b/tests/pkiunittest.py
@@ -44,7 +44,6 @@ PYPATH = os.path.abspath("..")
 
 TEST_PATH = ''
 
-# TODO: chdir strategy is a little silly
 def test_env_setup():
     """Create a test dir and environment"""
     # Required for cleanup and tests


### PR DESCRIPTION
I assumed that `ConfigParser` would stop reading after it successfully found a file. 