### PR TITLE
Handle failed response if HTTPS succeeds and HTTP fails

### DIFF
--- a/osgpkitools/ConnectAPI.py
+++ b/osgpkitools/ConnectAPI.py
@@ -70,11 +70,13 @@ class ConnectAPI(object):
 
         if not response:
             raise socket.error('Could not reach %s: %s' % (host_no_port, last_network_error))
+        elif 'FAILED' in json_data or not 'OK' in response.reason:
+            print_failure_reason_exit(json_data)
 
         try:
             self.reqid = json_data['host_request_id']
         except KeyError:
-            raise OIMException('ERROR: OIM did not return request ID in its response')
+            raise OIMException('OIM did not return request ID in its response')
 
     def request_authenticated(self, config, bulk_csr, ssl_context, vo=None, cc_list=None):
         """For registered user(gridadmin) certificate requests

--- a/osgpkitools/osg-cert-request
+++ b/osgpkitools/osg-cert-request
@@ -213,22 +213,20 @@ if __name__ == '__main__':
     except (socket.error, httplib.HTTPException) as exc:
         OSGPKIUtils.charlimit_textwrap('Connection failed: %s' % repr(exc))
     except FileNotFoundException as exc:
-        OSGPKIUtils.charlimit_textwrap(exc.message + ':' + exc.filename)
+        OSGPKIUtils.charlimit_textwrap(str(exc) + ':' + exc.filename)
         sys.exit(1)
     except (Exception_500response, NotOKException) as exc:
         OSGPKIUtils.charlimit_textwrap('Request Failed. Status %s' % exc.status)
-        OSGPKIUtils.charlimit_textwrap('Reason for failure %s' % exc.message)
+        OSGPKIUtils.charlimit_textwrap('Reason for failure %s' % str(exc))
         sys.exit(1)
     except CertificateMismatchException as exc:
         print 'The number of requests made was ', exc.request_num
         print 'The number of certificates received is ', exc.retrieve_num
-        OSGPKIUtils.charlimit_textwrap(exc.message)
+        OSGPKIUtils.charlimit_textwrap(str(exc))
         sys.exit(1)
-    except (BadPassphraseException, HandshakeFailureException, UnexpectedBehaviourException, InvalidOptionException) as exc:
-        OSGPKIUtils.charlimit_textwrap(exc.message)
-        sys.exit(1)
-    except (EOFError, OSError, KeyError, IOError) as exc:
-        OSGPKIUtils.print_exception_message(exc)
+    except (ConnectAPI.OIMException, EOFError, OSError, KeyError, IOError, BadPassphraseException,
+            HandshakeFailureException, UnexpectedBehaviourException, InvalidOptionException) as exc:
+        OSGPKIUtils.charlimit_textwrap('ERROR: ' + str(exc))
         sys.exit(1)
     except Exception:
         OSGPKIUtils.print_uncaught_exception()

--- a/osgpkitools/osg-gridadmin-cert-request
+++ b/osgpkitools/osg-gridadmin-cert-request
@@ -307,33 +307,31 @@ if __name__ == '__main__':
         charlimit_textwrap('Connection failed: %s' % exc)
         sys.exit(1)
     except FileWriteException as exc:
-        charlimit_textwrap(exc.message)
+        charlimit_textwrap(str(exc))
         charlimit_textwrap("The script will exit now\n")
         sys.exit(1)
     except FileNotFoundException as exc:
-        charlimit_textwrap(exc.message + ':' + exc.filename)
+        charlimit_textwrap(str(exc) + ':' + exc.filename)
         sys.exit(1)
     except (Exception_500response, NotOKException) as exc:
         charlimit_textwrap('Request Failed. Status %s' % exc.status)
-        charlimit_textwrap('Reason for failure %s' % exc.message)
+        charlimit_textwrap('Reason for failure %s' % str(exc))
         sys.exit(1)
     except CertificateMismatchException as exc:
         print 'The number of requests made was ', exc.request_num
         print 'The number of certificates received is ', exc.retrieve_num
-        charlimit_textwrap(exc.message)
+        charlimit_textwrap(str(exc))
         sys.exit(1)
     except InsufficientArgumentException as exc:
         # I agree with mat on JIRA Software 1072 on that if a user enters
         # the script without options, there is no bug and shouldn't be
         # reported to goc. Hence bypassing call to print exception message
-        charlimit_textwrap(exc.message)
+        charlimit_textwrap(str(exc))
         sys.stderr.write("Usage: osg-gridadmin-cert-request -h for help \n")
         sys.exit(2) # Fix for returning exit code of 2 as in all the other scripts.
-    except (BadCertificateException, BadPassphraseException, HandshakeFailureException) as exc:
-        charlimit_textwrap(exc.message)
-        sys.exit(1)
-    except (AttributeError, EnvironmentError, ValueError, EOFError, SSL.SSLError, UnexpectedBehaviourException) as exc:
-        print_exception_message(exc)
+    except (BadCertificateException, BadPassphraseException, HandshakeFailureException, ConnectAPI.OIMException,
+            AttributeError, EnvironmentError, ValueError, EOFError, SSL.SSLError, UnexpectedBehaviourException) as exc:
+        charlimit_textwrap(str(exc))
         sys.exit(1)
     except Exception:
         print_uncaught_exception()


### PR DESCRIPTION
Also fix deprecated usage of BaseException.message