### PR TITLE
Changes to allow running locally with a virtualenv

### DIFF
--- a/osgpkitools/osg-cert-request
+++ b/osgpkitools/osg-cert-request
@@ -1,4 +1,8 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+
+import os, sys
+if __name__ == "__main__" and __package__ is None:
+    sys.path.append(os.path.abspath(__file__+"/../.."))
 
 from osgpkitools import request
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+M2Crypto
+argparse


### PR DESCRIPTION
This should keep you from having to install it; you can just make a virtualenv, install the requirements, and run the script.

Works on ingwe (EL6); M2Crypto fails to build on my laptop (F28) -- that might indicate an issue we'll run into for EL8.