### PR TITLE
Fixing issue with relative paths starting with tilde

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ by InCommon that is authorized to create host certificates for that account.
 ### Synopsis ###
 
 ```
-Usage: osg-incommon-cert-request [--debug] -u username [-k pkey -c cert] \
+Usage: osg-incommon-cert-request [--debug] -u username -k pkey -c cert \
            (-H hostname | -f hostfile) [-a altnames] [-d write_directory]
-       osg-incommon-cert-request [--debug] -u username [-k pkey -c cert] -T
+       osg-incommon-cert-request [--debug] -u username -k pkey -c cert -T
        osg-incommon-cert-request -h
        osg-incommon-cert-request --version
 ```

--- a/osgpkitools/incommon_request.py
+++ b/osgpkitools/incommon_request.py
@@ -189,7 +189,6 @@ or specify from a file using -f/--hostfile.''')
         if not args.hostname:
             if not os.path.exists(hostfile):
                 raise FileNotFoundException(hostfile, 'Error: could not locate the hostfile')
-            
 
     arguments = dict()
 
@@ -204,10 +203,13 @@ or specify from a file using -f/--hostfile.''')
     arguments.update({'test': args.test})
     arguments.update({'login': args.login})
     
-    if args.usercert and args.userprivkey:
-        usercert, userkey = utils.find_user_cred(args.usercert, args.userprivkey)
-        arguments.update({'usercert': usercert})
-        arguments.update({'userprivkey': userkey})
+    if not args.usercert or not args.userprivkey:
+        raise InsufficientArgumentException("InsufficientArgumentException: " + \
+                                            "Please provide certificate(-c, --cert) and key(-k, --pkey) files\n")
+    
+    usercert, userkey = utils.verify_user_cred(args.usercert, args.userprivkey)
+    arguments.update({'usercert': usercert})
+    arguments.update({'userprivkey': userkey})
 
     arguments.update({'certdir': args.write_directory})
     
@@ -346,6 +348,7 @@ def main():
         CONFIG = dict(config_parser.items('InCommon'))
 
         ARGS = parse_args()
+
         utils.check_permissions(ARGS['certdir'])
         
         # Creating SSLContext with cert and key provided
@@ -424,7 +427,7 @@ def main():
     except SystemExit:
         raise
     except IOError as exc:
-        utils.charlimit_textwrap('Certificate and/or key files not found. More details below:')
+        utils.charlimit_textwrap('Certificate and/or key files were not found. More details below:')
         utils.print_exception_message(exc)
         sys.exit(1)
     except KeyboardInterrupt as exc:

--- a/osgpkitools/incommon_request.py
+++ b/osgpkitools/incommon_request.py
@@ -112,8 +112,7 @@ or specify from a file using -f/--hostfile.''')
         '--pkey',
         action='store',
         dest='userprivkey',
-        help="Specify Requestor's private key (PEM Format). If not specified " + \
-             "will take the value of X509_USER_KEY or $HOME/.globus/userkey.pem",
+        help="Specify requestor's private key (PEM Format)",
         metavar='PKEY',
         default=None
     )
@@ -122,8 +121,7 @@ or specify from a file using -f/--hostfile.''')
         '--cert',
         action='store',
         dest='usercert',
-        help="Specify requestor's user certificate (PEM Format). If not specified " + \
-             "will take the value of X509_USER_CERT or $HOME/.globus/usercert.pem",
+        help="Specify requestor's user certificate (PEM Format)",
         metavar='CERT',
         default=None
     )

--- a/osgpkitools/incommon_request.py
+++ b/osgpkitools/incommon_request.py
@@ -69,9 +69,9 @@ def parse_args():
     in a dictionary that is used throughout the script."""
 
     usage = \
-'''Usage: %prog [--debug] -u username [-k pkey -c cert] \\
+'''Usage: %prog [--debug] -u username -k pkey -c cert \\
            (-H hostname | -f hostfile) [-a altnames] [-d write_directory]
-       %prog [--debug] -u username [-k pkey -c cert] -T
+       %prog [--debug] -u username -k pkey -c cert -T
        %prog -h
        %prog --version'''
     parser = OptionParser(usage, version=utils.VERSION_NUMBER)

--- a/osgpkitools/utils.py
+++ b/osgpkitools/utils.py
@@ -140,35 +140,27 @@ def check_permissions(path):
         raise FileWriteException("User does not have appropriate permissions for writing to " + path)
 
 
-def find_user_cred(usercert=None, userkey=None):
-    """Find a readable user cert/key pair, trying pairs in the following order:
-    1. usercert, userkey
-    2. X509_USER_CERT, X509_USER_KEY environment variables
-    3. '~/.globus/usercert.pem', '~/.globus/userkey.pem'
-    INPUT (optional)
-    usercert: path to user certificate
-    userkey: path to private key of user
-    OUTPUT
-    Paths to the user cert and key
+def verify_user_cred(usercert, userkey):
+    """Verify the  readable user cert/key pair
+    INPUT
+        usercert: path to user certificate 
+        userkey: path to private key of user 
+    OUTPUT 
+        Paths to the verified user cert and key 
     """
-    
-    # list of cert/key pairs to try
-    input_pairs = [(usercert, userkey),
-                   ((os.environ.get('X509_USER_CERT'), os.environ.get('X509_USER_KEY'))),
-                   (os.path.expanduser('~/.globus/usercert.pem'), os.path.expanduser('~/.globus/userkey.pem'))]
-    cert_key_pairs = [t for t in input_pairs if None not in t] # remove undefined pairs for an improved err msg below
 
+    cert = os.path.expanduser(usercert)
+    key = os.path.expanduser(userkey)
+    
     # M2Crypto doesn't raise exceptions when encountering missing or unreadable
-    # cert/key pairs so we force the issue
-    for cert, key in cert_key_pairs:
-        try:
-            open(cert, 'r')
-            open(key, 'r')
-            return cert, key
-        except IOError:
-            continue
-    raise IOError("Unable to read the following certificate/key pairs:\n- %s" %
-                  "\n- ".join([", ".join(pair) for pair in cert_key_pairs]))
+    # cert/key pair so we force the issue
+
+    try:
+        open(cert, 'r')
+        open(key, 'r')
+        return cert, key
+    except IOError:
+        raise IOError("Unable to read the certificate/key pair at:  %s" % cert + " " + key)
 
 
 def print_failure_reason_exit(data):


### PR DESCRIPTION
This fix is for an error reported by an FNAL user:
File not found when a relative path was provided for a cert and/or a key file preceded by an equal sign

`--cert=~/path/to/cert`

Also removed the fallback path for cert and key: X509_USER_CERT and X509_USER_KEY, ~/.globus/usercert.pem and ~/.globus/userkey.pem 