### PR TITLE
Fixing option parsing, error messages -failure cases-

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ by InCommon that is authorized to create host certificates for that account.
 
 ```
 Usage: osg-incommon-cert-request [--debug] -u username -k pkey -c cert \
-           (-H hostname | -f hostfile) [-a altnames] [-d write_directory]
-       osg-incommon-cert-request [--debug] -u username -k pkey -c cert -T
+           (-H hostname | -F hostfile) [-a altnames] [-d write_directory]
+       osg-incommon-cert-request [--debug] -u username -k pkey -c cert -t
        osg-incommon-cert-request -h
        osg-incommon-cert-request --version
 ```

--- a/osgpkitools/ExceptionDefinitions.py
+++ b/osgpkitools/ExceptionDefinitions.py
@@ -48,16 +48,6 @@ class BadPassphraseException(Exception):
         return str(self.message)
 
 
-class InsufficientArgumentException(Exception):
-    """This exception is raised when insufficient number of arguments are passed to a script."""
-
-    def __init__(self, message):
-        self.message = message
-
-    def __str__(self):
-        return str(self.message)
-
-
 class FileWriteException(Exception):
     """This exception is raised when the user does not have permission to write in the current directory"""
 

--- a/osgpkitools/incommon_request.py
+++ b/osgpkitools/incommon_request.py
@@ -171,17 +171,17 @@ def test_incommon_connection(config, restclient):
     logger.debug('response text: ' + str(response_text))
     try:
         if response.status == 200:
-            print(prog + ": " + "Connection successful to InCommon API") 
+            print(prog + ": Connection successful to InCommon API") 
         else:
             # InCommon API HTTP Error codes and messages are not consistent with documentation.
-            print(prog + ": " + "Connection failure to InCommon API")
+            print(prog + ": Connection failure to InCommon API")
 
             if response.status == 401:
                 print("Check your authentication credentials")
 
-        print("HTTP " + str(response.status) + " " + str(response.reason))
+            print("HTTP " + str(response.status) + " " + str(response.reason))
     except httplib.HTTPException as exc:
-        print(prog + ": " + "HTTPS Connection error. Details: \n %s" % str(exc))
+        print(prog + ": HTTPS Connection error. Details: \n %s" % str(exc))
 
 
 def submit_request(config, restclient, hostname, cert_csr, sans=None):
@@ -223,9 +223,10 @@ def submit_request(config, restclient, hostname, cert_csr, sans=None):
         elif response.status == 401:
             raise AuthenticationFailureException(response.status, "Connection failure to InCommon API. Check your authentication credentials.")
         else:
-            raise httplib.HTTPException(response.status, "Connection failure to InCommon API")
+            print(prog + ": Connection failure to InCommon API. HTTP " + str(response.status) + " " + str(response.reason))
+            raise httplib.HTTPException()
     except httplib.HTTPException as exc:
-        raise httplib.HTTPException("Connection failure to InCommon API: " + exc) 
+        raise  
     
     return response_data
     
@@ -392,8 +393,10 @@ def main():
     except SSLError as exc:
         print(prog + ": " + str(exc))
         sys.exit('Please check for valid certificate.\n')
-    except (FileWriteException, BadPassphraseException, AttributeError, EnvironmentError, ValueError, EOFError, SSLError, AuthenticationFailureException, httplib.HTTPException) as exc:
+    except (FileWriteException, BadPassphraseException, AttributeError, EnvironmentError, ValueError, EOFError, SSLError, AuthenticationFailureException) as exc:
         print(prog + ": error " + str(exc))
+        sys.exit(1)
+    except httplib.HTTPException as exc:
         sys.exit(1)
     except Exception:
         traceback.print_exc()

--- a/osgpkitools/incommon_request.py
+++ b/osgpkitools/incommon_request.py
@@ -376,11 +376,6 @@ def main():
         raise
     except ValueError as exc:
         sys.exit(exc)
-    except IOError as exc:
-        print(prog + ": error: more details below:")
-        traceback.print_exc()
-        print(str(exc))
-        sys.exit(1)
     except KeyboardInterrupt as exc:
         print(str(exc))
         sys.exit('''Interrupted by user\n''')
@@ -393,8 +388,8 @@ def main():
     except SSLError as exc:
         print(prog + ": " + str(exc))
         sys.exit('Please check for valid certificate.\n')
-    except (FileWriteException, BadPassphraseException, AttributeError, EnvironmentError, ValueError, EOFError, SSLError, AuthenticationFailureException) as exc:
-        print(prog + ": error " + str(exc))
+    except (IOError, FileWriteException, BadPassphraseException, AttributeError, EnvironmentError, ValueError, EOFError, SSLError, AuthenticationFailureException) as exc:
+        print(prog + ": error: " + str(exc))
         sys.exit(1)
     except httplib.HTTPException as exc:
         print(str(exc))

--- a/osgpkitools/incommon_request.py
+++ b/osgpkitools/incommon_request.py
@@ -397,6 +397,7 @@ def main():
         print(prog + ": error " + str(exc))
         sys.exit(1)
     except httplib.HTTPException as exc:
+        print(str(exc))
         sys.exit(1)
     except Exception:
         traceback.print_exc()

--- a/osgpkitools/rest_client.py
+++ b/osgpkitools/rest_client.py
@@ -4,6 +4,7 @@ import socket
 import M2Crypto
 import urllib
 
+prog = "osg-incommon-cert-request"
 from json import dumps
 from urlparse import urljoin
 
@@ -49,7 +50,7 @@ class InCommonApiClient():
             utils.check_response_500(post_response)
             logger.debug('post response status ' + str(post_response.status) + ': ' + str(post_response.reason))
         except httplib.HTTPException as exc:
-            utils.charlimit_textwrap('Connection to %s failed : %s' % (url, exc))
+            print(prog + ": error: Connection to %s failed : %s" % (url, exc))
             raise
 
         return post_response
@@ -68,14 +69,12 @@ class InCommonApiClient():
         try:
             self.connection.request("GET", url, None, headers)
             get_response = self.connection.getresponse()
-            
             utils.check_response_500(get_response)
-        
             logger.debug('get response status ' + str(get_response.status) + ': ' + str(get_response.reason))
         except httplib.BadStatusLine as exc:
             raise
         except httplib.HTTPException as exc:
-            utils.charlimit_textwrap('Connection to %s failed : %s' % (url, exc))
+            print(prog + ": error: Connection to %s failed : %s" % (url, exc))
             raise
        
         return get_response

--- a/osgpkitools/utils.py
+++ b/osgpkitools/utils.py
@@ -15,7 +15,7 @@ from StringIO import StringIO
 
 from ExceptionDefinitions import *
 
-VERSION_NUMBER = "3.1.1"
+VERSION_NUMBER = "3.2.0"
 HELP_EMAIL = 'help@opensciencegrid.org'
 
 

--- a/osgpkitools/utils.py
+++ b/osgpkitools/utils.py
@@ -19,27 +19,6 @@ VERSION_NUMBER = "3.1.1"
 HELP_EMAIL = 'help@opensciencegrid.org'
 
 
-def print_exception_message(exc):
-    """Checks if the str representation of the exception is empty or not
-    if empty, it prints an generic error message stating the type of exception
-    and traceback.
-    """
-
-    if str(exc) != "":
-        print("Got an exception %s" % exc.__class__.__name__)
-        print(exc)
-    else:
-        handle_empty_exceptions(exc)
-
-
-def handle_empty_exceptions(exc):
-    """The method handles all empty exceptions and displays a meaningful message and
-    traceback for such exceptions."""
-
-    print(traceback.format_exc())
-    print('Encountered exception of type %s' % exc.__class__.__name__)
-
-
 def atomic_write(filename, contents):
     """Write to a temporary file then move it to its final location
     """

--- a/osgpkitools/utils.py
+++ b/osgpkitools/utils.py
@@ -19,15 +19,6 @@ VERSION_NUMBER = "3.1.1"
 HELP_EMAIL = 'help@opensciencegrid.org'
 
 
-def charlimit_textwrap(string):
-    """This function wraps up the output to 80 characters. Accepts string and print the wrapped output"""
-
-    list_string = textwrap.wrap(str(string), width=80)
-    for line in list_string:
-        print(line)
-    return
-
-
 def print_exception_message(exc):
     """Checks if the str representation of the exception is empty or not
     if empty, it prints an generic error message stating the type of exception
@@ -35,9 +26,8 @@ def print_exception_message(exc):
     """
 
     if str(exc) != "":
-        charlimit_textwrap("Got an exception %s" % exc.__class__.__name__)
-        charlimit_textwrap(exc)
-        #charlimit_textwrap('Please report the bug to %s.' % HELP_EMAIL)
+        print("Got an exception %s" % exc.__class__.__name__)
+        print(exc)
     else:
         handle_empty_exceptions(exc)
 
@@ -47,8 +37,7 @@ def handle_empty_exceptions(exc):
     traceback for such exceptions."""
 
     print(traceback.format_exc())
-    charlimit_textwrap('Encountered exception of type %s' % exc.__class__.__name__)
-    #charlimit_textwrap('Please report the bug to %s.' % HELP_EMAIL)
+    print('Encountered exception of type %s' % exc.__class__.__name__)
 
 
 def atomic_write(filename, contents):
@@ -76,7 +65,7 @@ def safe_rename(filename):
         print("Renamed existing file from %s to %s" % (filename, old_filename))
     except IOError, exc:
         if exc.errno != errno.ENOENT:
-            charlimit_textwrap(exc)
+            print(exc)
             raise RuntimeError('ERROR: Failed to rename %s to %s' % (filename, old_filename))
 
 
@@ -94,40 +83,3 @@ def check_permissions(path):
         return
     else:
         raise FileWriteException("User does not have appropriate permissions for writing to " + path)
-
-
-def verify_user_cred(usercert, userkey):
-    """Verify the  readable user cert/key pair
-    INPUT
-        usercert: path to user certificate 
-        userkey: path to private key of user 
-    OUTPUT 
-        Paths to the verified user cert and key 
-    """
-
-    cert = os.path.expanduser(usercert)
-    key = os.path.expanduser(userkey)
-    
-    # M2Crypto doesn't raise exceptions when encountering missing or unreadable
-    # cert/key pair so we force the issue
-
-    try:
-        open(cert, 'r')
-        open(key, 'r')
-        return cert, key
-    except IOError:
-        raise IOError("Unable to read the certificate/key pair at:  %s" % cert + " " + key)
-
-
-def print_failure_reason_exit(data):
-    """This functions prints the failure reasons and exits"""
-    try:
-        msg = 'The request has failed for the following reason: %s' % \
-        json.loads(data)['detail'].split('--')[1].lstrip()
-    except IndexError:
-        msg = 'The request has failed for the following reason: %s' % json.loads(data)['detail'].lstrip() + \
-              'Status : %s ' % json.loads(data)['status']
-
-    separator = '='*80
-    sys.exit('\n'.join(textwrap.wrap(separator + msg, width=80)))
-

--- a/rpm/osg-pki-tools.spec
+++ b/rpm/osg-pki-tools.spec
@@ -36,8 +36,13 @@ rm -f %{buildroot}%{python_sitelib}/*.egg-info
 %changelog
 * Tue Mar 26 2019 Jeny Teheran <jteheran@fnal.gov> - 3.2.0
 - Change -f/--hostfile to -F/--hostfile
+- Change -T/--test to -t/--test
 - Switch argparsing to ArgumentParser
+- Validate if filepath exists and can be read at the ArgumentParser
+- Stop wrapping text messages
+- Include the program name in error messages
 - Show message per certificate when request or retrieval fails
+- Increased the number of retries for certificate retrieval
 
 * Mon Mar 18 2019 Dave Dykstra <dwd@fnal.gov> - 3.1.1-1
 - Rename request.py to cert_request.py

--- a/rpm/osg-pki-tools.spec
+++ b/rpm/osg-pki-tools.spec
@@ -1,6 +1,6 @@
 Summary: osg-pki-tools
 Name: osg-pki-tools
-Version: 3.1.1
+Version: 3.2.0
 Release: 1%{?dist}
 Source: osg-pki-tools-%{version}.tar.gz
 License: Apache 2.0
@@ -34,6 +34,11 @@ rm -f %{buildroot}%{python_sitelib}/*.egg-info
 
 
 %changelog
+* Tue Mar 26 2019 Jeny Teheran <jteheran@fnal.gov> - 3.2.0
+- Change -f/--hostfile to -F/--hostfile
+- Switch argparsing to ArgumentParser
+- Show message per certificate when request or retrieval fails
+
 * Mon Mar 18 2019 Dave Dykstra <dwd@fnal.gov> - 3.1.1-1
 - Rename request.py to cert_request.py
 - Move common crypto code to cert_utils.py


### PR DESCRIPTION
1) Switch to ArgumentParser
2) Removed the use of utils.charlimit_textwrap
3) Added error messages for failure cases on certificate request and retrieval (after timeout).