### PR TITLE
Fixing error when timeout (incomplete format), increased wait_time

### DIFF
--- a/osgpkitools/incommon_request.py
+++ b/osgpkitools/incommon_request.py
@@ -39,7 +39,7 @@ from ExceptionDefinitions import *
 from rest_client import InCommonApiClient
 
 MAX_RETRY_RETRIEVAL = 40
-WAIT_RETRIEVAL= 5
+WAIT_RETRIEVAL= 10
 WAIT_APPROVAL = 30
 
 CONFIG_TEXT = """[InCommon]
@@ -366,7 +366,7 @@ def main():
                 utils.atomic_write(cert_path, response_retrieve)
                 os.chmod(cert_path, 0644)
             else:
-                print("Retrieval failure for %" % subj)
+                print("Retrieval failure for %s" % subj)
                 print("The certificate can be retrieved directly from the InCommon Cert Manager interface.")
                 print("CN %s, Self-enrollment Certificate ID (sslId): %s" % (subj, request[0]))
             

--- a/osgpkitools/utils.py
+++ b/osgpkitools/utils.py
@@ -15,7 +15,7 @@ from StringIO import StringIO
 
 from ExceptionDefinitions import *
 
-VERSION_NUMBER = "3.2.1"
+VERSION_NUMBER = "3.2.2"
 HELP_EMAIL = 'help@opensciencegrid.org'
 
 

--- a/rpm/osg-pki-tools.spec
+++ b/rpm/osg-pki-tools.spec
@@ -1,6 +1,6 @@
 Summary: osg-pki-tools
 Name: osg-pki-tools
-Version: 3.2.1
+Version: 3.2.2
 Release: 1%{?dist}
 Source: osg-pki-tools-%{version}.tar.gz
 License: Apache 2.0
@@ -36,7 +36,10 @@ gzip -c man/osg-incommon-cert-request.1 >%{buildroot}%{_datadir}/man/man1/osg-in
 %{_datadir}/man/man1/osg-incommon-cert-request*
 
 %changelog
-#- Improve formatting of osg-incommon-cert-request man page
+* Tue Apr 9 2019 Jeny Teheran <jteheran@fnal.gov> - 3.2.2
+- Fix format error for message when retrieval times out
+- Increased the wait time between retrieval attempts
+- Improve formatting of osg-incommon-cert-request man page
 
 * Wed Mar 27 2019 Jeny Teheran <jteheran@fnal.gov> - 3.2.1
 - Add man page for osg-incommon-cert-request


### PR DESCRIPTION
One of our users reported an error: incomplete format when the retrieval times out. 
There was an 's' missing from one print error message. 
I also increased the wait time between retrievals to 10. InCommon is experiencing issues with their backend for approval.