### PR TITLE
Add new option: organization and department code

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ by InCommon that is authorized to create host certificates for that account.
 Usage: osg-incommon-cert-request [--debug] -u username -k pkey -c cert \
            (-H hostname | -F hostfile) [-a altnames] [-d write_directory]
        osg-incommon-cert-request [--debug] -u username -k pkey -c cert -t
+       osg-incommon-cert-request [--orgcode org,dept] (-H hostname | \
+       -F hostfile) -u username -k pkey -c cert
        osg-incommon-cert-request -h
        osg-incommon-cert-request --version
 ```

--- a/README.md
+++ b/README.md
@@ -45,10 +45,9 @@ by InCommon that is authorized to create host certificates for that account.
 
 ```
 Usage: osg-incommon-cert-request [--debug] -u username -k pkey -c cert \
-           (-H hostname | -F hostfile) [-a altnames] [-d write_directory]
+           (-H hostname | -F hostfile) [-a altnames] [-d write_directory] \
+           [-O org,dept]
        osg-incommon-cert-request [--debug] -u username -k pkey -c cert -t
-       osg-incommon-cert-request [--orgcode org,dept] (-H hostname | \
-       -F hostfile) -u username -k pkey -c cert
        osg-incommon-cert-request -h
        osg-incommon-cert-request --version
 ```

--- a/man/osg-incommon-cert-request.1
+++ b/man/osg-incommon-cert-request.1
@@ -54,7 +54,7 @@ To generate a certificate with no Subject Alternative Names (SANS)
 .RS
 .nf
 osg-incommon-cert-request -u incommonuser -c certpath.pem \\
--k keypath.pem -H hostname.yourdomain
+    -k keypath.pem -H hostname.yourdomain
 .fi
 .RE
 .PP
@@ -63,8 +63,8 @@ To generate a certificate with multiple Subject Alternative Names (SANS)
 .RS
 .nf
 osg-incommon-cert-request -u incommonuser -c certpath.pem \\
--k keypath.pem -H hostname.yourdomain -a hostalt.yourdomain \\
--a hostalt2.yourdomain 
+    -k keypath.pem -H hostname.yourdomain -a hostalt.yourdomain \\
+    -a hostalt2.yourdomain 
 .fi
 .RE
 .PP
@@ -73,7 +73,7 @@ To generate multiple certificates from a hostfile
 .RS
 .nf
 osg-incommon-cert-request -u incommonuser -c certpath.pem \\
--k keypath.pem -F hostfilepath.txt
+    -k keypath.pem -F hostfilepath.txt
 .RE
 .PP
 hostfilepath.txt example 
@@ -91,7 +91,7 @@ To provide alternative organization and department codes for the InCommon Certif
 .RS
 .nf
 osg-incommon-cert-request -O 4567,8912 -u incommonuser \\
--c certpath.pem -k keypath.pem -H hostname.yourdomain
+    -c certpath.pem -k keypath.pem -H hostname.yourdomain
 .fi
 .RE
 .PP

--- a/man/osg-incommon-cert-request.1
+++ b/man/osg-incommon-cert-request.1
@@ -96,12 +96,10 @@ osg-incommon-cert-request -O 4567,8912 -u incommonuser \\
 .RE
 .PP
 Codes can be found at the InCommon Cert Manager web interface (https://cert-manager.com/customer/InCommon):
-.RS
-.IP
-\- Organization Code is shown as OrgID under Settings > Organizations > Edit
-.IP
-\- Department Code is shown as OrgID under Settings > Organizations > Departments > Edit
-.RE
+.IP - 2
+Organization Code is shown as OrgID under Settings > Organizations > Edit
+.IP - 2
+Department Code is shown as OrgID under Settings > Organizations > Departments > Edit
 .SH AUTHOR
 Jeny Teheran
 

--- a/man/osg-incommon-cert-request.1
+++ b/man/osg-incommon-cert-request.1
@@ -1,16 +1,15 @@
 .TH osg-incommon-cert-request 1
 .SH NAME
-osg-incommon-cert-request \- retrieves host and service certificates from the \\
-InCommon CA
+osg-incommon-cert-request \- retrieves host and service certificates from the InCommon CA
 .SH SYNOPSIS
 .B osg-incommon-cert-request
 .RI [ OPTION ]...
 .SH DESCRIPTION
 .B osg-incommon-cert-request
-retrieves host and service certificates from the InCommon IGTF Server CA. 
-It requires an Incommon user account authorized as a Department 
+retrieves host and service certificates from the InCommon IGTF Server CA.
+It requires an Incommon user account authorized as a Department
 Registration Authority to issue InCommon IGTF Server CA certificates  
-with SSL auto approval. 
+with SSL auto approval.
 It authenticates the requestor with an InCommon client certificate.
 .PP
 It allows bulk retrieval of certificates and keys. 
@@ -29,8 +28,7 @@ Write debug output to stdout.
 Testing mode: test connection to InCommon API but does not request certificates.
 .TP
 .BR \-u, \-\-username
-Specify requestor's InCommon username/login. Use the same login credential as \\
-InCommon Cert Manager. It is typically an email address.
+Specify requestor's InCommon username/login. Use the same login credential as InCommon Cert Manager. It is typically an email address.
 .TP
 .BR \-c, \-\-cert
 Specify requestor's user certificate (PEM format).
@@ -48,16 +46,15 @@ May be specified more than once for additional SANs.
 The directory to write the host certificate(s) and key(s).
 .TP
 .BR \-O, \-\-orgcode
-Specify alternative organization and department codes for the InCommon \\
-Certificate Service. Defaults are Fermilab\'s codes.
+Specify alternative organization and department codes for the InCommon Certificate Service.
 .SH EXAMPLES
 .PP
 To generate a certificate with no Subject Alternative Names (SANS)
 .PP
 .RS
 .nf
-osg-incommon-cert-request -u incommonuser -c certpath.pem -k keypath.pem \\
--H hostname.yourdomain
+osg-incommon-cert-request -u incommonuser -c certpath.pem \\
+-k keypath.pem -H hostname.yourdomain
 .fi
 .RE
 .PP
@@ -65,8 +62,9 @@ To generate a certificate with multiple Subject Alternative Names (SANS)
 .PP
 .RS
 .nf
-osg-incommon-cert-request -u incommonuser -c certpath.pem -k keypath.pem \\
--H hostname.yourdomain -a hostalt.yourdomain -a hostalt2.yourdomain 
+osg-incommon-cert-request -u incommonuser -c certpath.pem \\
+-k keypath.pem -H hostname.yourdomain -a hostalt.yourdomain \\
+-a hostalt2.yourdomain 
 .fi
 .RE
 .PP
@@ -74,8 +72,8 @@ To generate multiple certificates from a hostfile
 .PP
 .RS
 .nf
-osg-incommon-cert-request -u incommonuser -c certpath.pem -k keypath.pem \\
--F hostfilepath.txt
+osg-incommon-cert-request -u incommonuser -c certpath.pem \\
+-k keypath.pem -F hostfilepath.txt
 .RE
 .PP
 hostfilepath.txt example 
@@ -88,20 +86,21 @@ hostname04.yourdomain hostname05.yourdomain
 .fi
 .RE
 .PP
-To provide alternative organization and department codes for the InCommon \\
-Certificate Service. Codes can be found at the InCommon Cert Manager web \\
-interface (https://cert-manager.com/customer/InCommon): \\
-.IP \[bu] 2
-Organization Code is shown as OrgID under Settings > Organizations > Edit
-.IP \[bu]
-Department Code is shown as OrgID under Settings > Organizations > \\
-Departments > Edit
+To provide alternative organization and department codes for the InCommon Certificate Service. 
 .PP
 .RS
 .nf
-osg-incommon-cert-request -O 4567,8912 -u incommonuser -c certpath.pem \\
--k keypath.pem -H hostname.yourdomain
+osg-incommon-cert-request -O 4567,8912 -u incommonuser \\
+-c certpath.pem -k keypath.pem -H hostname.yourdomain
 .fi
+.RE
+.PP
+Codes can be found at the InCommon Cert Manager web interface (https://cert-manager.com/customer/InCommon):
+.RS
+.IP
+\- Organization Code is shown as OrgID under Settings > Organizations > Edit
+.IP
+\- Department Code is shown as OrgID under Settings > Organizations > Departments > Edit
 .RE
 .SH AUTHOR
 Jeny Teheran

--- a/man/osg-incommon-cert-request.1
+++ b/man/osg-incommon-cert-request.1
@@ -44,6 +44,9 @@ May be specified more than once for additional SANs.
 .TP
 .BR \-d, \-\-directory
 The directory to write the host certificate(s) and key(s).
+.TP
+.BR \-O, \-\-orgcode
+Specify alternative organization and department codes for the InCommon Certificate Service. Defaults are Fermilab\'s codes.
 .SH EXAMPLES
 .PP
 To generate a certificate with no Subject Alternative Names (SANS)
@@ -77,6 +80,14 @@ hostname01.yourdomain
 hostname02.yourdomain hostnamealias.yourdomain hostname03.yourdomain
 hostname04.yourdomain hostname05.yourdomain
 .RE
+.fi
+.RE
+.PP
+To provide alternative organization and department codes for the InCommon Certificate Service. 
+.PP
+.RS
+.nf
+osg-incommon-cert-request -O 4567,8912 -u incommonuser -c certpath.pem -k keypath.pem -H hostname.yourdomain
 .fi
 .RE
 .SH AUTHOR

--- a/man/osg-incommon-cert-request.1
+++ b/man/osg-incommon-cert-request.1
@@ -1,6 +1,7 @@
 .TH osg-incommon-cert-request 1
 .SH NAME
-osg-incommon-cert-request \- retrieves host and service certificates from the InCommon CA
+osg-incommon-cert-request \- retrieves host and service certificates from the \\
+InCommon CA
 .SH SYNOPSIS
 .B osg-incommon-cert-request
 .RI [ OPTION ]...
@@ -28,7 +29,8 @@ Write debug output to stdout.
 Testing mode: test connection to InCommon API but does not request certificates.
 .TP
 .BR \-u, \-\-username
-Specify requestor's InCommon username/login. Use the same login credential as InCommon Cert Manager. It is typically an email address.
+Specify requestor's InCommon username/login. Use the same login credential as \\
+InCommon Cert Manager. It is typically an email address.
 .TP
 .BR \-c, \-\-cert
 Specify requestor's user certificate (PEM format).
@@ -46,14 +48,16 @@ May be specified more than once for additional SANs.
 The directory to write the host certificate(s) and key(s).
 .TP
 .BR \-O, \-\-orgcode
-Specify alternative organization and department codes for the InCommon Certificate Service. Defaults are Fermilab\'s codes.
+Specify alternative organization and department codes for the InCommon \\
+Certificate Service. Defaults are Fermilab\'s codes.
 .SH EXAMPLES
 .PP
 To generate a certificate with no Subject Alternative Names (SANS)
 .PP
 .RS
 .nf
-osg-incommon-cert-request -u incommonuser -c certpath.pem -k keypath.pem -H hostname.yourdomain
+osg-incommon-cert-request -u incommonuser -c certpath.pem -k keypath.pem \\
+-H hostname.yourdomain
 .fi
 .RE
 .PP
@@ -61,8 +65,8 @@ To generate a certificate with multiple Subject Alternative Names (SANS)
 .PP
 .RS
 .nf
-osg-incommon-cert-request -u incommonuser -c certpath.pem -k keypath.pem -H hostname.yourdomain \\ 
--a hostalternative.yourdomain -a hostalternative2.yourdomain 
+osg-incommon-cert-request -u incommonuser -c certpath.pem -k keypath.pem \\
+-H hostname.yourdomain -a hostalt.yourdomain -a hostalt2.yourdomain 
 .fi
 .RE
 .PP
@@ -70,24 +74,33 @@ To generate multiple certificates from a hostfile
 .PP
 .RS
 .nf
-osg-incommon-cert-request -u incommonuser -c certpath.pem -k keypath.pem -F hostfilepath.txt
+osg-incommon-cert-request -u incommonuser -c certpath.pem -k keypath.pem \\
+-F hostfilepath.txt
 .RE
 .PP
 hostfilepath.txt example 
 .PP
 .RS
 hostname01.yourdomain
-hostname02.yourdomain hostnamealias.yourdomain hostname03.yourdomain
+hostname02.yourdomain althostname.yourdomain hostname03.yourdomain
 hostname04.yourdomain hostname05.yourdomain
 .RE
 .fi
 .RE
 .PP
-To provide alternative organization and department codes for the InCommon Certificate Service. 
+To provide alternative organization and department codes for the InCommon \\
+Certificate Service. Codes can be found at the InCommon Cert Manager web \\
+interface (https://cert-manager.com/customer/InCommon): \\
+.IP \[bu] 2
+Organization Code is shown as OrgID under Settings > Organizations > Edit
+.IP \[bu]
+Department Code is shown as OrgID under Settings > Organizations > \\
+Departments > Edit
 .PP
 .RS
 .nf
-osg-incommon-cert-request -O 4567,8912 -u incommonuser -c certpath.pem -k keypath.pem -H hostname.yourdomain
+osg-incommon-cert-request -O 4567,8912 -u incommonuser -c certpath.pem \\
+-k keypath.pem -H hostname.yourdomain
 .fi
 .RE
 .SH AUTHOR

--- a/man/osgincommoncertrequest.html
+++ b/man/osgincommoncertrequest.html
@@ -1,5 +1,5 @@
 <!-- Creator     : groff version 1.22.2 -->
-<!-- CreationDate: Wed May  8 12:10:28 2019 -->
+<!-- CreationDate: Mon May 13 10:18:58 2019 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -37,7 +37,7 @@
 
 
 <p style="margin-left:11%; margin-top: 1em">osg-incommon-cert-request
-&minus; retrieves host and service certificates from the
+&minus; retrieves host and service certificates from the \
 InCommon CA</p>
 
 <h2>SYNOPSIS
@@ -94,7 +94,7 @@ certificates.</p>
 <p style="margin-left:11%;"><b>&minus;u,</b>&minus;&minus;username</p>
 
 <p style="margin-left:22%;">Specify requestor&rsquo;s
-InCommon username/login. Use the same login credential as
+InCommon username/login. Use the same login credential as \
 InCommon Cert Manager. It is typically an email address.</p>
 
 
@@ -127,7 +127,7 @@ certificate(s) and key(s).</p>
 <p style="margin-left:11%;"><b>&minus;O,</b>&minus;&minus;orgcode</p>
 
 <p style="margin-left:22%;">Specify alternative
-organization and department codes for the InCommon
+organization and department codes for the InCommon \
 Certificate Service. Defaults are Fermilab&acute;s
 codes.</p>
 
@@ -141,8 +141,8 @@ certificate with no Subject Alternative Names (SANS)</p>
 
 
 <p style="margin-left:22%; margin-top: 1em">osg-incommon-cert-request
--u incommonuser -c certpath.pem -k keypath.pem -H
-hostname.yourdomain</p>
+-u incommonuser -c certpath.pem -k keypath.pem \ <br>
+-H hostname.yourdomain</p>
 
 <p style="margin-left:11%; margin-top: 1em">To generate a
 certificate with multiple Subject Alternative Names
@@ -150,18 +150,17 @@ certificate with multiple Subject Alternative Names
 
 
 <p style="margin-left:22%; margin-top: 1em">osg-incommon-cert-request
--u incommonuser -c certpath.pem -k keypath.pem -H
-hostname.yourdomain \ <br>
--a hostalternative.yourdomain -a
-hostalternative2.yourdomain</p>
+-u incommonuser -c certpath.pem -k keypath.pem \ <br>
+-H hostname.yourdomain -a hostalt.yourdomain -a
+hostalt2.yourdomain</p>
 
 <p style="margin-left:11%; margin-top: 1em">To generate
 multiple certificates from a hostfile</p>
 
 
 <p style="margin-left:22%; margin-top: 1em">osg-incommon-cert-request
--u incommonuser -c certpath.pem -k keypath.pem -F
-hostfilepath.txt</p>
+-u incommonuser -c certpath.pem -k keypath.pem \ <br>
+-F hostfilepath.txt</p>
 
 
 <p style="margin-left:11%; margin-top: 1em">hostfilepath.txt
@@ -170,18 +169,48 @@ example</p>
 
 <p style="margin-left:22%; margin-top: 1em">hostname01.yourdomain
 <br>
-hostname02.yourdomain hostnamealias.yourdomain
+hostname02.yourdomain althostname.yourdomain
 hostname03.yourdomain <br>
 hostname04.yourdomain hostname05.yourdomain</p>
 
 <p style="margin-left:11%; margin-top: 1em">To provide
 alternative organization and department codes for the
-InCommon Certificate Service.</p>
+InCommon \ Certificate Service. Codes can be found at the
+InCommon Cert Manager web \ interface
+(https://cert-manager.com/customer/InCommon): \</p>
+
+<table width="100%" border="0" rules="none" frame="void"
+       cellspacing="0" cellpadding="0">
+<tr valign="top" align="left">
+<td width="11%"></td>
+<td width="1%">
+
+
+<p>&bull;</p></td>
+<td width="2%"></td>
+<td width="86%">
+
+
+<p>Organization Code is shown as OrgID under Settings &gt;
+Organizations &gt; Edit</p></td></tr>
+<tr valign="top" align="left">
+<td width="11%"></td>
+<td width="1%">
+
+
+<p>&bull;</p></td>
+<td width="2%"></td>
+<td width="86%">
+
+
+<p>Department Code is shown as OrgID under Settings &gt;
+Organizations &gt; \ Departments &gt; Edit</p></td></tr>
+</table>
 
 
 <p style="margin-left:22%; margin-top: 1em">osg-incommon-cert-request
--O 4567,8912 -u incommonuser -c certpath.pem -k keypath.pem
--H hostname.yourdomain</p>
+-O 4567,8912 -u incommonuser -c certpath.pem \ <br>
+-k keypath.pem -H hostname.yourdomain</p>
 
 <h2>AUTHOR
 <a name="AUTHOR"></a>

--- a/man/osgincommoncertrequest.html
+++ b/man/osgincommoncertrequest.html
@@ -1,14 +1,25 @@
-<!-- Creator     : groff version 1.18.1.4 -->
-<!-- CreationDate: Thu Mar 28 21:23:08 2019 -->
+<!-- Creator     : groff version 1.22.2 -->
+<!-- CreationDate: Wed May  8 12:10:28 2019 -->
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta name="generator" content="groff -Thtml, see www.gnu.org">
+<meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <meta name="Content-Style" content="text/css">
+<style type="text/css">
+       p       { margin-top: 0; margin-bottom: 0; vertical-align: top }
+       pre     { margin-top: 0; margin-bottom: 0; vertical-align: top }
+       table   { margin-top: 0; margin-bottom: 0; vertical-align: top }
+       h1      { text-align: center }
+</style>
 <title>osg-incommon-cert-request</title>
+
 </head>
 <body>
 
-<h1 align=center>osg-incommon-cert-request</h1>
+<h1 align="center">osg-incommon-cert-request</h1>
+
 <a href="#NAME">NAME</a><br>
 <a href="#SYNOPSIS">SYNOPSIS</a><br>
 <a href="#DESCRIPTION">DESCRIPTION</a><br>
@@ -17,277 +28,168 @@
 <a href="#AUTHOR">AUTHOR</a><br>
 
 <hr>
+
+
+<h2>NAME
 <a name="NAME"></a>
-<h2>NAME</h2>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="10%"></td>
-<td width="89%">
-<p>osg-incommon-cert-request &minus; retrieves host and
-service certificates from the InCommon CA</p>
-</td>
-</table>
+</h2>
+
+
+
+<p style="margin-left:11%; margin-top: 1em">osg-incommon-cert-request
+&minus; retrieves host and service certificates from the
+InCommon CA</p>
+
+<h2>SYNOPSIS
 <a name="SYNOPSIS"></a>
-<h2>SYNOPSIS</h2>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="10%"></td>
-<td width="89%">
-<p><b>osg-incommon-cert-request</b> [<i>OPTION</i>]...</p>
-</td>
-</table>
+</h2>
+
+
+
+<p style="margin-left:11%; margin-top: 1em"><b>osg-incommon-cert-request</b>
+[<i>OPTION</i>]...</p>
+
+<h2>DESCRIPTION
 <a name="DESCRIPTION"></a>
-<h2>DESCRIPTION</h2>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="10%"></td>
-<td width="89%">
-<p><b>osg-incommon-cert-request</b> retrieves host and
-service certificates from the InCommon IGTF Server CA. It
-requires an Incommon user account authorized as a Department
-Registration Authority to issue InCommon IGTF Server CA
-certificates with SSL auto approval. It authenticates the
-requestor with an InCommon client certificate.</p>
-<!-- INDENTATION -->
-<p>It allows bulk retrieval of certificates and keys.</p>
-</td>
-</table>
+</h2>
+
+
+
+<p style="margin-left:11%; margin-top: 1em"><b>osg-incommon-cert-request</b>
+retrieves host and service certificates from the InCommon
+IGTF Server CA. It requires an Incommon user account
+authorized as a Department Registration Authority to issue
+InCommon IGTF Server CA certificates with SSL auto approval.
+It authenticates the requestor with an InCommon client
+certificate.</p>
+
+<p style="margin-left:11%; margin-top: 1em">It allows bulk
+retrieval of certificates and keys.</p>
+
+<h2>OPTIONS
 <a name="OPTIONS"></a>
-<h2>OPTIONS</h2>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="10%"></td>
-<td width="89%">
-<p><b>&minus;&minus;version</b></p></td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="21%"></td>
-<td width="77%">
-<p>Show the program&rsquo;s version number and exit.</p>
-</td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="10%"></td>
-<td width="89%">
-<p><b>&minus;h,</b> &minus;&minus;help</p></td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="21%"></td>
-<td width="77%">
-<p>Show a help message and exit.</p>
-</td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="10%"></td>
-<td width="89%">
-<p><b>&minus;&minus;debug</b></p></td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="21%"></td>
-<td width="77%">
-<p>Write debug output to stdout.
+</h2>
+
+
+
+<p style="margin-left:11%; margin-top: 1em"><b>&minus;&minus;version</b></p>
+
+<p style="margin-left:22%;">Show the program&rsquo;s
+version number and exit.</p>
+
+
+<p style="margin-left:11%;"><b>&minus;h,&nbsp;</b>&minus;&minus;help</p>
+
+<p style="margin-left:22%;">Show a help message and
+exit.</p>
+
+<p style="margin-left:11%;"><b>&minus;&minus;debug</b></p>
+
+<p style="margin-left:22%;">Write debug output to stdout.
 <b>&minus;t,</b>&minus;&minus;test Testing mode: test
 connection to InCommon API but does not request
 certificates.</p>
-</td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="10%"></td>
-<td width="89%">
-<p><b>&minus;u,</b>&minus;&minus;username</p></td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="21%"></td>
-<td width="77%">
-<p>Specify requestor&rsquo;s InCommon username/login. Use
-the same login credential as InCommon Cert Manager. It is
-typically an email address.</p>
-</td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="10%"></td>
-<td width="89%">
-<p><b>&minus;c,</b>&minus;&minus;cert</p></td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="21%"></td>
-<td width="77%">
-<p>Specify requestor&rsquo;s user certificate (PEM
-format).</p>
-</td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="10%"></td>
-<td width="89%">
-<p><b>&minus;k,</b>&minus;&minus;pkey</p></td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="21%"></td>
-<td width="77%">
-<p>Specify requestor&rsquo;s private key (PEM format).</p>
-</td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="10%"></td>
-<td width="89%">
-<p><b>&minus;a,</b>&minus;&minus;altname</p></td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="21%"></td>
-<td width="77%">
-<p>Specify a Subject Alternative Name (SAN) for the
-requested certificate (only works with <i>&minus;H,
-&minus;&minus;hostname).</i> May be specified more than once
-for additional SANs.</p>
-</td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="10%"></td>
-<td width="89%">
-<p><b>&minus;d,</b>&minus;&minus;directory</p></td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="21%"></td>
-<td width="77%">
-<p>The directory to write the host certificate(s) and
-key(s).</p>
-</td>
-</table>
+
+
+<p style="margin-left:11%;"><b>&minus;u,</b>&minus;&minus;username</p>
+
+<p style="margin-left:22%;">Specify requestor&rsquo;s
+InCommon username/login. Use the same login credential as
+InCommon Cert Manager. It is typically an email address.</p>
+
+
+<p style="margin-left:11%;"><b>&minus;c,</b>&minus;&minus;cert</p>
+
+<p style="margin-left:22%;">Specify requestor&rsquo;s user
+certificate (PEM format).</p>
+
+
+<p style="margin-left:11%;"><b>&minus;k,</b>&minus;&minus;pkey</p>
+
+<p style="margin-left:22%;">Specify requestor&rsquo;s
+private key (PEM format).</p>
+
+
+<p style="margin-left:11%;"><b>&minus;a,</b>&minus;&minus;altname</p>
+
+<p style="margin-left:22%;">Specify a Subject Alternative
+Name (SAN) for the requested certificate (only works with
+<i>&minus;H, &minus;&minus;hostname).</i> May be specified
+more than once for additional SANs.</p>
+
+
+<p style="margin-left:11%;"><b>&minus;d,</b>&minus;&minus;directory</p>
+
+<p style="margin-left:22%;">The directory to write the host
+certificate(s) and key(s).</p>
+
+
+<p style="margin-left:11%;"><b>&minus;O,</b>&minus;&minus;orgcode</p>
+
+<p style="margin-left:22%;">Specify alternative
+organization and department codes for the InCommon
+Certificate Service. Defaults are Fermilab&acute;s
+codes.</p>
+
+<h2>EXAMPLES
 <a name="EXAMPLES"></a>
-<h2>EXAMPLES</h2>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="10%"></td>
-<td width="89%">
-<p>To generate a certificate with no Subject Alternative
-Names (SANS)</p>
-</td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="20%"></td>
-<td width="79%">
-<pre>osg-incommon-cert-request -u incommonuser -c certpath.pem -k keypath.pem -H hostname.yourdomain
-</pre>
-</td>
-</table>
-<!-- INDENTATION -->
+</h2>
 
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="10%"></td>
-<td width="89%">
-<p>To generate a certificate with multiple Subject
-Alternative Names (SANS)</p>
-</td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="20%"></td>
-<td width="79%">
-<pre>osg-incommon-cert-request -u incommonuser -c certpath.pem -k keypath.pem -H hostname.yourdomain \
--a hostalternative.yourdomain -a hostalternative2.yourdomain
-</pre>
-</td>
-</table>
-<!-- INDENTATION -->
 
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="10%"></td>
-<td width="89%">
-<p>To generate multiple certificates from a hostfile</p>
-</td>
-</table>
-<!-- INDENTATION -->
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="20%"></td>
-<td width="79%">
-<pre>osg-incommon-cert-request -u incommonuser -c certpath.pem -k keypath.pem -F hostfilepath.txt
+<p style="margin-left:11%; margin-top: 1em">To generate a
+certificate with no Subject Alternative Names (SANS)</p>
 
-hostfilepath.txt example
 
-hostname01.yourdomain
-hostname02.yourdomain hostnamealias.yourdomain hostname03.yourdomain
-hostname04.yourdomain hostname05.yourdomain
-</pre>
-</td>
-</table>
+<p style="margin-left:22%; margin-top: 1em">osg-incommon-cert-request
+-u incommonuser -c certpath.pem -k keypath.pem -H
+hostname.yourdomain</p>
+
+<p style="margin-left:11%; margin-top: 1em">To generate a
+certificate with multiple Subject Alternative Names
+(SANS)</p>
+
+
+<p style="margin-left:22%; margin-top: 1em">osg-incommon-cert-request
+-u incommonuser -c certpath.pem -k keypath.pem -H
+hostname.yourdomain \ <br>
+-a hostalternative.yourdomain -a
+hostalternative2.yourdomain</p>
+
+<p style="margin-left:11%; margin-top: 1em">To generate
+multiple certificates from a hostfile</p>
+
+
+<p style="margin-left:22%; margin-top: 1em">osg-incommon-cert-request
+-u incommonuser -c certpath.pem -k keypath.pem -F
+hostfilepath.txt</p>
+
+
+<p style="margin-left:11%; margin-top: 1em">hostfilepath.txt
+example</p>
+
+
+<p style="margin-left:22%; margin-top: 1em">hostname01.yourdomain
+<br>
+hostname02.yourdomain hostnamealias.yourdomain
+hostname03.yourdomain <br>
+hostname04.yourdomain hostname05.yourdomain</p>
+
+<p style="margin-left:11%; margin-top: 1em">To provide
+alternative organization and department codes for the
+InCommon Certificate Service.</p>
+
+
+<p style="margin-left:22%; margin-top: 1em">osg-incommon-cert-request
+-O 4567,8912 -u incommonuser -c certpath.pem -k keypath.pem
+-H hostname.yourdomain</p>
+
+<h2>AUTHOR
 <a name="AUTHOR"></a>
-<h2>AUTHOR</h2>
-<!-- INDENTATION -->
+</h2>
 
-<table width="100%" border=0 rules="none" frame="void"
-       cols="2" cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="10%"></td>
-<td width="89%">
-<p>Jeny Teheran</p>
-</td>
-</table>
+
+<p style="margin-left:11%; margin-top: 1em">Jeny
+Teheran</p>
 <hr>
 </body>
 </html>

--- a/man/osgincommoncertrequest.html
+++ b/man/osgincommoncertrequest.html
@@ -1,5 +1,5 @@
 <!-- Creator     : groff version 1.22.2 -->
-<!-- CreationDate: Mon May 13 11:30:20 2019 -->
+<!-- CreationDate: Mon May 13 15:00:38 2019 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>

--- a/man/osgincommoncertrequest.html
+++ b/man/osgincommoncertrequest.html
@@ -1,5 +1,5 @@
 <!-- Creator     : groff version 1.22.2 -->
-<!-- CreationDate: Mon May 13 10:18:58 2019 -->
+<!-- CreationDate: Mon May 13 11:30:20 2019 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -37,7 +37,7 @@
 
 
 <p style="margin-left:11%; margin-top: 1em">osg-incommon-cert-request
-&minus; retrieves host and service certificates from the \
+&minus; retrieves host and service certificates from the
 InCommon CA</p>
 
 <h2>SYNOPSIS
@@ -94,7 +94,7 @@ certificates.</p>
 <p style="margin-left:11%;"><b>&minus;u,</b>&minus;&minus;username</p>
 
 <p style="margin-left:22%;">Specify requestor&rsquo;s
-InCommon username/login. Use the same login credential as \
+InCommon username/login. Use the same login credential as
 InCommon Cert Manager. It is typically an email address.</p>
 
 
@@ -127,9 +127,8 @@ certificate(s) and key(s).</p>
 <p style="margin-left:11%;"><b>&minus;O,</b>&minus;&minus;orgcode</p>
 
 <p style="margin-left:22%;">Specify alternative
-organization and department codes for the InCommon \
-Certificate Service. Defaults are Fermilab&acute;s
-codes.</p>
+organization and department codes for the InCommon
+Certificate Service.</p>
 
 <h2>EXAMPLES
 <a name="EXAMPLES"></a>
@@ -141,8 +140,8 @@ certificate with no Subject Alternative Names (SANS)</p>
 
 
 <p style="margin-left:22%; margin-top: 1em">osg-incommon-cert-request
--u incommonuser -c certpath.pem -k keypath.pem \ <br>
--H hostname.yourdomain</p>
+-u incommonuser -c certpath.pem \ <br>
+-k keypath.pem -H hostname.yourdomain</p>
 
 <p style="margin-left:11%; margin-top: 1em">To generate a
 certificate with multiple Subject Alternative Names
@@ -150,17 +149,18 @@ certificate with multiple Subject Alternative Names
 
 
 <p style="margin-left:22%; margin-top: 1em">osg-incommon-cert-request
--u incommonuser -c certpath.pem -k keypath.pem \ <br>
--H hostname.yourdomain -a hostalt.yourdomain -a
-hostalt2.yourdomain</p>
+-u incommonuser -c certpath.pem \ <br>
+-k keypath.pem -H hostname.yourdomain -a hostalt.yourdomain
+\ <br>
+-a hostalt2.yourdomain</p>
 
 <p style="margin-left:11%; margin-top: 1em">To generate
 multiple certificates from a hostfile</p>
 
 
 <p style="margin-left:22%; margin-top: 1em">osg-incommon-cert-request
--u incommonuser -c certpath.pem -k keypath.pem \ <br>
--F hostfilepath.txt</p>
+-u incommonuser -c certpath.pem \ <br>
+-k keypath.pem -F hostfilepath.txt</p>
 
 
 <p style="margin-left:11%; margin-top: 1em">hostfilepath.txt
@@ -175,42 +175,24 @@ hostname04.yourdomain hostname05.yourdomain</p>
 
 <p style="margin-left:11%; margin-top: 1em">To provide
 alternative organization and department codes for the
-InCommon \ Certificate Service. Codes can be found at the
-InCommon Cert Manager web \ interface
-(https://cert-manager.com/customer/InCommon): \</p>
-
-<table width="100%" border="0" rules="none" frame="void"
-       cellspacing="0" cellpadding="0">
-<tr valign="top" align="left">
-<td width="11%"></td>
-<td width="1%">
-
-
-<p>&bull;</p></td>
-<td width="2%"></td>
-<td width="86%">
-
-
-<p>Organization Code is shown as OrgID under Settings &gt;
-Organizations &gt; Edit</p></td></tr>
-<tr valign="top" align="left">
-<td width="11%"></td>
-<td width="1%">
-
-
-<p>&bull;</p></td>
-<td width="2%"></td>
-<td width="86%">
-
-
-<p>Department Code is shown as OrgID under Settings &gt;
-Organizations &gt; \ Departments &gt; Edit</p></td></tr>
-</table>
+InCommon Certificate Service.</p>
 
 
 <p style="margin-left:22%; margin-top: 1em">osg-incommon-cert-request
--O 4567,8912 -u incommonuser -c certpath.pem \ <br>
--k keypath.pem -H hostname.yourdomain</p>
+-O 4567,8912 -u incommonuser \ <br>
+-c certpath.pem -k keypath.pem -H hostname.yourdomain</p>
+
+<p style="margin-left:11%; margin-top: 1em">Codes can be
+found at the InCommon Cert Manager web interface
+(https://cert-manager.com/customer/InCommon):</p>
+
+<p style="margin-left:32%; margin-top: 1em">&minus;
+Organization Code is shown as OrgID under Settings &gt;
+Organizations &gt; Edit</p>
+
+<p style="margin-left:32%; margin-top: 1em">&minus;
+Department Code is shown as OrgID under Settings &gt;
+Organizations &gt; Departments &gt; Edit</p>
 
 <h2>AUTHOR
 <a name="AUTHOR"></a>

--- a/osgpkitools/incommon_request.py
+++ b/osgpkitools/incommon_request.py
@@ -68,9 +68,9 @@ def parse_cli():
     
     usage = \
     '''%(prog)s [--debug] -u username -k pkey -c cert \\
-           (-H hostname | -F hostfile) [-a altnames] [-d write_directory]
+           (-H hostname | -F hostfile) [-a altnames] [-d write_directory] \\
+           [-O org,dept]
        %(prog)s [--debug] -u username -k pkey -c cert -t
-       %(prog)s [--orgcode org,dept] (-H hostname | -F hostfile) -u username -k pkey -c cert
        %(prog)s -h
        %(prog)s --version'''
  
@@ -290,7 +290,8 @@ def main():
             codes = [code.strip() for code in args.orgcode.split(',')]
             CONFIG['organization'] = codes[0]
             CONFIG['department'] = codes[1]
-            print("Switching organization code to %s and department code to %s" % (CONFIG['organization'], CONFIG['department']))
+        
+        print("Using organization code of %s and department code of %s" % (CONFIG['organization'], CONFIG['department']))
 
         utils.check_permissions(args.write_directory)
          

--- a/osgpkitools/incommon_request.py
+++ b/osgpkitools/incommon_request.py
@@ -70,6 +70,7 @@ def parse_cli():
     '''%(prog)s [--debug] -u username -k pkey -c cert \\
            (-H hostname | -F hostfile) [-a altnames] [-d write_directory]
        %(prog)s [--debug] -u username -k pkey -c cert -t
+       %(prog)s [--orgcode org,dept] (-H hostname | -F hostfile) -u username -k pkey -c cert
        %(prog)s -h
        %(prog)s --version'''
  
@@ -101,10 +102,8 @@ def parse_cli():
                           'May be specified more than once for additional SANs.')
     optional.add_argument('-d', '--directory', action='store', dest='write_directory', default='.',
                           help="The directory to write the host certificate(s) and key(s)")
-    optional.add_argument('-O', '--organization', action='store', dest='organization', default='9697',
-                          help='The organization identifier for the InCommon Certificate Service')
-    optional.add_argument('-OU', '--department', action='store', dest='department', default='9732',
-                          help='The department identifier for the InCommon Certificate Service')
+    optional.add_argument('-O', '--orgcode', action='store', dest='orgcode', default='9697,9732',
+                          help='Organization and Department codes for the InCommon Certificate Service. Defaults are Fermilab\'s codes.')
     optional.add_argument('--debug', action='store_true', dest='debug', default=False,
                           help="Write debug output to stdout")
     optional.add_argument('-t', '--test', action='store_true', dest='test', default=False,
@@ -286,9 +285,15 @@ def main():
         config_parser = ConfigParser.ConfigParser()
         config_parser.readfp(StringIO(CONFIG_TEXT))
         CONFIG = dict(config_parser.items('InCommon'))
+        
+        if args.orgcode:
+            codes = [code.strip() for code in args.orgcode.split(',')]
+            CONFIG['organization'] = codes[0]
+            CONFIG['department'] = codes[1]
+            print("Switching organization code to %s and department code to %s" % (CONFIG['organization'], CONFIG['department']))
 
         utils.check_permissions(args.write_directory)
-        
+         
         if args.test:
             print("Beginning testing mode: ignoring optional parameters.")
             print("="*60)

--- a/osgpkitools/incommon_request.py
+++ b/osgpkitools/incommon_request.py
@@ -101,6 +101,10 @@ def parse_cli():
                           'May be specified more than once for additional SANs.')
     optional.add_argument('-d', '--directory', action='store', dest='write_directory', default='.',
                           help="The directory to write the host certificate(s) and key(s)")
+    optional.add_argument('-O', '--organization', action='store', dest='organization', default='9697',
+                          help='The organization identifier for the InCommon Certificate Service')
+    optional.add_argument('-OU', '--department', action='store', dest='department', default='9732',
+                          help='The department identifier for the InCommon Certificate Service')
     optional.add_argument('--debug', action='store_true', dest='debug', default=False,
                           help="Write debug output to stdout")
     optional.add_argument('-t', '--test', action='store_true', dest='test', default=False,

--- a/osgpkitools/incommon_request.py
+++ b/osgpkitools/incommon_request.py
@@ -102,7 +102,7 @@ def parse_cli():
                           'May be specified more than once for additional SANs.')
     optional.add_argument('-d', '--directory', action='store', dest='write_directory', default='.',
                           help="The directory to write the host certificate(s) and key(s)")
-    optional.add_argument('-O', '--orgcode', action='store', dest='orgcode', default='9697,9732',
+    optional.add_argument('-O', '--orgcode', action='store', dest='orgcode', default='9697,9732', metavar='ORG,DEPT',
                           help='Organization and Department codes for the InCommon Certificate Service. Defaults are Fermilab\'s codes.')
     optional.add_argument('--debug', action='store_true', dest='debug', default=False,
                           help="Write debug output to stdout")

--- a/osgpkitools/utils.py
+++ b/osgpkitools/utils.py
@@ -15,7 +15,7 @@ from StringIO import StringIO
 
 from ExceptionDefinitions import *
 
-VERSION_NUMBER = "3.2.2"
+VERSION_NUMBER = "3.2.3"
 HELP_EMAIL = 'help@opensciencegrid.org'
 
 

--- a/rpm/osg-pki-tools.spec
+++ b/rpm/osg-pki-tools.spec
@@ -1,6 +1,6 @@
 Summary: osg-pki-tools
 Name: osg-pki-tools
-Version: 3.2.2
+Version: 3.2.3
 Release: 1%{?dist}
 Source: osg-pki-tools-%{version}.tar.gz
 License: Apache 2.0
@@ -36,6 +36,9 @@ gzip -c man/osg-incommon-cert-request.1 >%{buildroot}%{_datadir}/man/man1/osg-in
 %{_datadir}/man/man1/osg-incommon-cert-request*
 
 %changelog
+* Wed May 8 2019 Jeny Teheran <jteheran@fnal.gov> - 3.2.3
+- Add organization and department code option
+
 * Tue Apr 9 2019 Jeny Teheran <jteheran@fnal.gov> - 3.2.2
 - Fix format error for message when retrieval times out
 - Increased the wait time between retrieval attempts


### PR DESCRIPTION
Please review usage, man page, .spec file.

@DrDaveD should we validate the amount of codes provided through the -O option? Right now, I'm just choosing the first two.