### PR TITLE
Strip whitespace and blank lines from hostfile lines

### DIFF
--- a/osgpkitools/cert_request.py
+++ b/osgpkitools/cert_request.py
@@ -103,8 +103,9 @@ def main():
         fqdns_list = [[args.hostname] + args.altnames]
     elif args.hostfile:
         with open(args.hostfile, 'r') as hfile:
-            hostfile = hfile.readlines()
-        fqdns_list = [re.split(r' +', x) for x in hostfile]
+            hostfiles = [x.strip() for x in hfile.readlines()]
+            hostfiles = [x for x in hostfiles if x]
+        fqdns_list = [re.split(r' +', x) for x in hostfiles]
 
     for fqdns in fqdns_list:
         print("Writing CSR for {0}...".format(fqdns[0]))


### PR DESCRIPTION
readlines() does not chop off the trailing newlines so they were getting into the hostnames. As long as I added code to handle those, I might as well remove all the leading/trailing whitespace and blank lines.