### PR TITLE
Add optional --organizational-unit flag to osg-cert-request (SOFTWARE-4121)

### DIFF
--- a/osgpkitools/cert_request.py
+++ b/osgpkitools/cert_request.py
@@ -42,6 +42,8 @@ def parse_cli(args):
     optional.add_argument('-a', '--altname', action='append', dest='altnames', default=[],
                           help='Specify the SAN for the requested certificate (only works with -H/--hostname). '
                           'May be specified more than once for additional SANs.')
+    required.add_argument('-U', '--organizational-unit', action='append', dest='organizational_unit', default=[],
+                          help='The organizational unit(s) to associate with the generated CSR(s)')
     optional.add_argument('-d', '--directory', action='store', dest='write_directory', default='.',
                           help="The directory to write the generated CSR(s) and host key(s)")
     optional.add_argument('-V', '--version', action='version', version=utils.VERSION_NUMBER)
@@ -96,8 +98,8 @@ def main():
     except ValueError as exc:
         sys.exit(exc)
 
-    location = namedtuple('Location', ['country', 'state', 'locality', 'organization'])
-    loc = location(args.country, args.state, args.locality, args.organization)
+    location = namedtuple('Location', ['country', 'state', 'locality', 'organization', 'organizational_unit'])
+    loc = location(args.country, args.state, args.locality, args.organization, args.organizational_unit)
 
     if args.hostname:
         fqdns_list = [[args.hostname] + args.altnames]

--- a/osgpkitools/cert_utils.py
+++ b/osgpkitools/cert_utils.py
@@ -38,7 +38,7 @@ def get_ssl_context(usercert, userkey):
         try:
             ssl_context.load_cert_chain(usercert, userkey, callback=prompt_for_password)
             return ssl_context
-        except SSL.SSLError, exc:
+        except SSL.SSLError as exc:
             if 'bad decrypt' in exc:
                 pass_str = 'Incorrect password. Please enter the password again for'
             else:

--- a/osgpkitools/cert_utils.py
+++ b/osgpkitools/cert_utils.py
@@ -97,6 +97,8 @@ class Csr(object):
             entries.append(('ST', location.state))
             entries.append(('L', location.locality))
             entries.append(('O', location.organization))
+            for ou in location.organizational_unit:
+                entries.append(('OU', ou))
         
         for key, val in entries:
             x509name.add_entry_by_txt(field=key, type=MBSTRING_ASC, entry=val, len=-1, loc=-1, set=0)

--- a/osgpkitools/cert_utils.py
+++ b/osgpkitools/cert_utils.py
@@ -146,9 +146,9 @@ class Csr(object):
         # this is like atomic_write except writing with save_key
         temp_fd, temp_name = tempfile.mkstemp(dir=self.output_dir)
         os.close(temp_fd)
+        os.chmod(temp_name, 0o600)
         self.keypair.save_key(temp_name, cipher=None)
         os.rename(temp_name, keypath)
-        os.chmod(keypath, 0600)
 
     def format_csr(self, csr):
         """Extract the base64 encoded string from the contents of a CSR"""

--- a/osgpkitools/cert_utils.py
+++ b/osgpkitools/cert_utils.py
@@ -90,7 +90,6 @@ class Csr(object):
         
         # Build entries for x509 name
         entries = list()
-        entries.append(('CN', hostname))
 
         if location:
             entries.append(('C', location.country))
@@ -99,6 +98,8 @@ class Csr(object):
             entries.append(('O', location.organization))
             for ou in location.organizational_unit:
                 entries.append(('OU', ou))
+
+        entries.append(('CN', hostname))
         
         for key, val in entries:
             x509name.add_entry_by_txt(field=key, type=MBSTRING_ASC, entry=val, len=-1, loc=-1, set=0)

--- a/osgpkitools/utils.py
+++ b/osgpkitools/utils.py
@@ -1,17 +1,10 @@
 #!/usr/bin/python
 
 from __future__ import print_function
-import ConfigParser
 import errno
 import os
 import shutil
-import sys
 import tempfile
-import textwrap
-import json
-import traceback
-import getpass
-from StringIO import StringIO
 
 from ExceptionDefinitions import *
 
@@ -42,7 +35,7 @@ def safe_rename(filename):
     try:
         shutil.move(filename, old_filename)
         print("Renamed existing file from %s to %s" % (filename, old_filename))
-    except IOError, exc:
+    except IOError as exc:
         if exc.errno != errno.ENOENT:
             print(exc)
             raise RuntimeError('ERROR: Failed to rename %s to %s' % (filename, old_filename))


### PR DESCRIPTION
Optionally include one or more OU entries in the DN when generating a CSR

Other minor changes:
- Chmod keyfile before writing the key
- Put the CN at the end of the DN, rather than the beginning
- Python 3 fixups and unused imports