### PR TITLE
don't open hostfile in binary mode (SOFTWARE-5197)

### DIFF
--- a/osgpkitools/incommon_request.py
+++ b/osgpkitools/incommon_request.py
@@ -318,7 +318,7 @@ def main():
         if args.hostname:
             hosts = [tuple([args.hostname.strip()] + args.altnames)]
         else:
-            with open(args.hostfile, 'rb') as hosts_file:
+            with open(args.hostfile) as hosts_file:
                 host_lines = hosts_file.readlines()
             hosts = [tuple(line.split()) for line in host_lines if line.strip()]
         


### PR DESCRIPTION
This "open(args.hostfile, 'rb')" has been there since the initial
import commit; so it seems to be a holdover from the python2 days.

The result is the lines read from the file are stored as bytes
(which used to be the same as str in python2), instead of unicode
(which of course is the same as str in python3).

The result is the common_name/hostname passed into the cert_utils.Csr()
`__init__` is a bytes, but it is used to construct a path with other
regular str (ie unicode) strings, which raises a TypeError for
trying to concat str to bytes.

(That's what it looks like is happening to me, anyway.)

...

For reference, here was the error from SOFTWARE-5197:

```
$ osg-incommon-cert-request -u sanders@phy.olemiss.edu -k ~/.globus/userkey.pem -c ~/.globus/usercert.pem -O 4351,9212  -F linuxfarmtest -d . 

Using organization code of 4351 and department code of 9212
Beginning certificate request
============================================================
The following Common Name (CN) and Subject Alternative Names (SANS) have been specified: 
CN: b'linuxfarmc.phy.olemiss.edu', SANS: ()
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/osgpkitools/incommon_request.py", line 335, in main
    csr_obj = cert_utils.Csr(common_name, output_dir=args.write_directory, altnames=sans)
  File "/usr/lib/python3.6/site-packages/osgpkitools/cert_utils.py", line 76, in __init__
    self.csrpath = os.path.join(output_dir, hostname + '.req')
TypeError: can't concat str to bytes
```