### PR TITLE
Fix set-output GHA deprecation warning (Software-5354)

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
   run-unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       - name: install m2crypto
         run: sudo apt-get install m2crypto


### PR DESCRIPTION
Fix deprecated Node.js 12 action with update to Node.js 16