### PR TITLE
Make osg-incommon-cert-request configurable (SOFTWARE-5668)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN yum update -y && \
     yum clean all && \
     rm -rf /var/cache/yum/* && \
     cd /src && \
-    python3 setup.py install --root=/
+    python3 setup.py install --root=/ && \
+    mkdir -p /etc/osg/pki && \
+    cp /usr/local/config/ca-issuer.conf /etc/osg/pki/
     
 WORKDIR /output
 

--- a/config/ca-issuer.conf
+++ b/config/ca-issuer.conf
@@ -1,0 +1,18 @@
+[InCommon]
+organization:
+department:
+customeruri: InCommon
+igtfservercert: 215
+igtfmultidomain: 283
+servertype: -1
+term: 395
+apiurl: cert-manager.com
+listingurl: /private/api/ssl/v1/types
+enrollurl: /private/api/ssl/v1/enroll
+retrieveurl: /private/api/ssl/v1/collect/
+sslid: sslId
+certx509: /x509
+certx509co: /x509CO
+certbase64: /base64
+certbin: /bin
+content_type: application/json

--- a/osgpkitools/incommon_request.py
+++ b/osgpkitools/incommon_request.py
@@ -43,25 +43,6 @@ MAX_RETRY_RETRIEVAL = 40
 WAIT_RETRIEVAL= 10
 WAIT_APPROVAL = 30
 
-CONFIG_TEXT = """[InCommon]
-organization: 9697
-department: 9732
-customeruri: InCommon
-igtfservercert: 215
-igtfmultidomain: 283
-servertype: -1
-term: 395
-apiurl: cert-manager.com
-listingurl: /private/api/ssl/v1/types
-enrollurl: /private/api/ssl/v1/enroll  
-retrieveurl: /private/api/ssl/v1/collect/
-sslid: sslId
-certx509: /x509
-certx509co: /x509CO
-certbase64: /base64
-certbin: /bin
-content_type: application/json
-"""
 
 def parse_cli():
     """This function parses all the arguments, validates them and then stores them
@@ -101,6 +82,8 @@ def parse_cli():
     optional.add_argument('-a', '--altname', action='append', dest='altnames', default=[],
                           help='Specify the SAN for the requested certificate (only works with -H/--hostname). '
                           'May be specified more than once for additional SANs.')
+    optional.add_argument('-C', '--config', action='store', dest='config_file', default='/etc/osg/pki/ca-issuer.conf'
+                          'Path to configuration file')
     optional.add_argument('-d', '--directory', action='store', dest='write_directory', default='.',
                           help="The directory to write the host certificate(s) and key(s)")
     optional.add_argument('-O', '--orgcode', action='store', dest='orgcode', default='9697,9732', metavar='ORG,DEPT',
@@ -286,7 +269,7 @@ def main():
         args = parse_cli()
    
         config_parser = configparser.ConfigParser()
-        config_parser.readfp(StringIO(CONFIG_TEXT))
+        config_parser.read(args.config_file)
         CONFIG = dict(config_parser.items('InCommon'))
         
         if args.orgcode:

--- a/rpm/osg-pki-tools.spec
+++ b/rpm/osg-pki-tools.spec
@@ -32,11 +32,15 @@ rm -f %{buildroot}%{python_sitelib}/*.egg-info
 mkdir -p %{buildroot}%{_datadir}/man/man1
 gzip -c man/osg-incommon-cert-request.1 >%{buildroot}%{_datadir}/man/man1/osg-incommon-cert-request.1.gz
 
+mkdir -p %{buildroot}%{_sysconfdir}/osg/pki
+mv %{buildroot}/%{_prefix}/config/ca-issuer.conf %{buildroot}%{_sysconfdir}/osg/pki/
+
 %files
 %{python3_sitelib}/osgpkitools
 %{_bindir}/osg-cert-request
 %{_bindir}/osg-incommon-cert-request
 %{_datadir}/man/man1/osg-incommon-cert-request*
+%config(noreplace) %{_sysconfdir}/osg/pki/ca-issuer.conf
 
 %changelog
 * Tue Mar 14 2023 Brian Lin <blin@cs.wisc.edu> - 3.5.2-2

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     author="Brian Lin",
     author_email="blin@cs.wisc.edu",
     scripts=["osgpkitools/osg-cert-request", "osgpkitools/osg-incommon-cert-request"],
+    data_files=[("config", ["config/ca-issuer.conf"])],
     description="Open Science Grid x509 certificate tools.",
     long_description="Open Science Grid x509 certificate tools.",
     packages=['osgpkitools'],


### PR DESCRIPTION
This will allow sites (FNAL) to swap behind the InCommon V1 and V3 CAs