### PR TITLE
Convert osg-incommon-cert-request to use urllib3, to fix for el9

### DIFF
--- a/osgpkitools/rest_client.py
+++ b/osgpkitools/rest_client.py
@@ -1,15 +1,15 @@
 import http.client
 import logging
 import socket
-import M2Crypto
-import urllib.request, urllib.parse, urllib.error
+import urllib3
+import urllib.parse
 
-prog = "osg-incommon-cert-request"
 from json import dumps
-from urllib.parse import urljoin
 
 from . import utils
 from .ExceptionDefinitions import *
+
+prog = "osg-incommon-cert-request"
 
 logger = logging.getLogger(__name__)
 
@@ -20,13 +20,18 @@ class InCommonApiClient():
 
         Args:
             base_url (string): Will be used to connect to the InCommon API (cert-auth) 
+            ssl_context (object): urllib3 SSL context including user credentials
         """
         
+        if not base_url.startswith("http"):
+            base_url = "https://" + base_url
         self.base_url = base_url
-        self.connection = M2Crypto.httpslib.HTTPSConnection(base_url, strict=False, ssl_context=ssl_context)
+
+        self.http = urllib3.PoolManager(ssl_context=ssl_context,
+                        timeout=urllib3.util.Timeout(connect=2, read=10))
     
     def close_connection(self):
-        self.connection.close()
+        self.http.clear()
 
     def post_request(self, url, headers, data):
         """
@@ -36,7 +41,7 @@ class InCommonApiClient():
             headers (json): additional headers to complete the request
         """
         
-        url = urljoin(self.base_url, url)
+        url = urllib.parse.urljoin(self.base_url, url)
         
         logger.debug('posting to ' + url)
         logger.debug('headers ' + str(headers))
@@ -45,12 +50,11 @@ class InCommonApiClient():
         params = urllib.parse.urlencode(data, doseq=True)
         
         try:
-            self.connection.request("POST", url, body=dumps(data), headers=headers)
-            post_response = self.connection.getresponse()
+            post_response = self.http.request("POST", url, body=dumps(data), headers=headers)
             utils.check_response_500(post_response)
             logger.debug('post response status ' + str(post_response.status) + ': ' + str(post_response.reason))
         except http.client.HTTPException as exc:
-            print((prog + f": error: Connection to {url} failed : {exc}"))
+            print((prog + f": error: post to {url} failed : {exc}"))
             raise
 
         return post_response
@@ -61,20 +65,19 @@ class InCommonApiClient():
             url (string): url to send the request
             headers (json): additional headers to complete the request
         """
-        url = urljoin(self.base_url, url)
+        url = urllib.parse.urljoin(self.base_url, url)
 
         logger.debug('requesting to ' + url)
         logger.debug('headers ' + str(headers))
         
         try:
-            self.connection.request("GET", url, None, headers)
-            get_response = self.connection.getresponse()
+            get_response = self.http.request("GET", url, None, headers)
             utils.check_response_500(get_response)
             logger.debug('get response status ' + str(get_response.status) + ': ' + str(get_response.reason))
         except http.client.BadStatusLine as exc:
             raise
         except http.client.HTTPException as exc:
-            print((prog + f": error: Connection to {url} failed : {exc}"))
+            print((prog + f": error: request from {url} failed : {exc}"))
             raise
        
         return get_response

--- a/rpm/osg-pki-tools.spec
+++ b/rpm/osg-pki-tools.spec
@@ -13,7 +13,7 @@ BuildArch: noarch
 BuildRequires: python3
 BuildRequires: python3-devel
 BuildRequires: python3-m2crypto
-Requires: python3-m2crypto
+BuildRequires: python3-urllib3
 
 %description
 %{summary}


### PR DESCRIPTION
This changes osg-incommon-cert-request to use urllib3 instead of M2Crypto, to make it work on el9.