### PR TITLE
Include ca_certs to urllib3, update to 3.7.1

### DIFF
--- a/osgpkitools/rest_client.py
+++ b/osgpkitools/rest_client.py
@@ -1,6 +1,7 @@
 import http.client
 import logging
 import socket
+import ssl
 import urllib3
 import urllib.parse
 
@@ -28,6 +29,7 @@ class InCommonApiClient():
         self.base_url = base_url
 
         self.http = urllib3.PoolManager(ssl_context=ssl_context,
+                        ca_certs=ssl.get_default_verify_paths().cafile,
                         timeout=urllib3.util.Timeout(connect=2, read=10))
     
     def close_connection(self):

--- a/osgpkitools/utils.py
+++ b/osgpkitools/utils.py
@@ -7,7 +7,7 @@ import tempfile
 
 from .ExceptionDefinitions import *
 
-VERSION_NUMBER = "3.7.0"
+VERSION_NUMBER = "3.7.1"
 HELP_EMAIL = 'help@opensciencegrid.org'
 
 

--- a/rpm/osg-pki-tools.spec
+++ b/rpm/osg-pki-tools.spec
@@ -1,6 +1,6 @@
 Summary: osg-pki-tools
 Name: osg-pki-tools
-Version: 3.7.0
+Version: 3.7.1
 Release: 1%{?dist}
 Source: osg-pki-tools-%{version}.tar.gz
 License: Apache 2.0
@@ -43,6 +43,9 @@ mv %{buildroot}/%{_prefix}/config/ca-issuer.conf %{buildroot}%{_sysconfdir}/osg/
 %config(noreplace) %{_sysconfdir}/osg/pki/ca-issuer.conf
 
 %changelog
+* Tue Feb 20 2024 Dave Dykstra <dwd@fnal.gov> - 3.7.1
+- Set the default ca_certs bundle for osg-incommon-cert-request.
+
 * Tue Feb 20 2024 Dave Dykstra <dwd@fnal.gov> - 3.7.0
 - Convert osg-incommon-cert-request to use urllib3 instead of M2crypto 
   for its https connection, to make it work properly on EL9.


### PR DESCRIPTION
During most of my testing of #82 I had been passing ca_certs to urllib3 using the python certifi module, and that turned out to be a challenge to put in rpm Requires so I took it out at the end.  I thought for sure I had tested the default setting but now it's not working for me.  So instead this PR specifies the ssl default cafile, and that works.  It also updates to version 3.7.1.