### PR TITLE
Fix bug with sending headers in restclient API

### DIFF
--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         yum_repo: ['development', 'testing', 'release']
-        osg_series: ['24']
+        osg_series: ['23', '24']
     steps:
       - uses: opensciencegrid/build-container-action@v0.6.1
         with:
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         yum_repo: ['development', 'testing', 'release']
-        osg_series: ['24']
+        osg_series: ['23', '24']
         registry:
           - url: hub.opensciencegrid.org
             username: OSG_HARBOR_ROBOT_USER

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -12,9 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         yum_repo: ['development', 'testing', 'release']
-        osg_series: ['3.6']
+        osg_series: ['24']
     steps:
-      - uses: opensciencegrid/build-container-action@v0.3.1
+      - uses: opensciencegrid/build-container-action@v0.6.1
         with:
           osg_series: ${{ matrix.osg_series }}
           repo: ${{ matrix.yum_repo }}
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         yum_repo: ['development', 'testing', 'release']
-        osg_series: ['3.6']
+        osg_series: ['24']
         registry:
           - url: hub.opensciencegrid.org
             username: OSG_HARBOR_ROBOT_USER

--- a/osgpkitools/rest_client.py
+++ b/osgpkitools/rest_client.py
@@ -76,7 +76,7 @@ class InCommonApiClient:
         logger.debug("headers " + str(headers))
 
         try:
-            get_response = self.http.request("GET", url, None, headers)
+            get_response = self.http.request("GET", url, None, headers=headers)
             utils.check_response_500(get_response)
             logger.debug("get response status " + str(get_response.status) + ": " + str(get_response.reason))
         except http.client.BadStatusLine as exc:

--- a/osgpkitools/utils.py
+++ b/osgpkitools/utils.py
@@ -7,7 +7,7 @@ import tempfile
 
 from .ExceptionDefinitions import *
 
-VERSION_NUMBER = "3.7.1"
+VERSION_NUMBER = "3.7.2"
 HELP_EMAIL = "help@opensciencegrid.org"
 
 

--- a/rpm/osg-pki-tools.spec
+++ b/rpm/osg-pki-tools.spec
@@ -1,7 +1,7 @@
 Summary: osg-pki-tools
 Name: osg-pki-tools
-Version: 3.7.1
-Release: 2%{?dist}
+Version: 3.7.2
+Release: 1%{?dist}
 Source: osg-pki-tools-%{version}.tar.gz
 License: Apache 2.0
 Group: Grid
@@ -44,6 +44,12 @@ mv %{buildroot}/%{_prefix}/config/ca-issuer.conf %{buildroot}%{_sysconfdir}/osg/
 %config(noreplace) %{_sysconfdir}/osg/pki/ca-issuer.conf
 
 %changelog
+* Fri Mar  7 2025 Dave Dykstra <dwd@fnal.gov> - 3.7.2
+- Fix bug in invocation of urllib3.request() in restclient's get_request();
+  it was passing headers as the 4th parameter instead of identifying it
+  by name.  Broke retrieval of cert with osg-incommon-cert-request in
+  some cases.
+
 * Wed Oct 23 2024 Matt Westphall <westphall@wisc.edu> - 3.7.1-2
 - Add python3-m2crpyto and python3-urllib3 as runtime requirements
 


### PR DESCRIPTION
Someone at Fermilab was getting errors retrieving a certificate with `osg-incommon-cert-request` and this patch fixed the problem.  The fourth parameter of `urllib3.request()` is not headers according to the [documentation](https://urllib3.readthedocs.io/en/stable/reference/urllib3.request.html).